### PR TITLE
Added basic filtering for status updates.

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -205,13 +205,37 @@ authz_cfg=authz.Authz(
 )
 c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))
 
-c['status'].append(GitHubStatus(
+def conditional_patch(cls, fnName, argNames):
+    old = getattr(cls, fnName)
+    build = argNames.index("build")
+    def patch_with(self, *args, **kwargs):
+        if build == 0:
+            if conditional_status(self):
+                old(self, *args, **kwargs)
+        elif build > 0:
+            if conditional_status(args[build - 1]):
+                old(self, *args, **kwargs)
+    setattr(cls, fnName, patch_with)
+
+# If this returns False then the status of the build is not reported.
+def conditional_status(build):
+    ss = build.getSourceStamps()[0]
+    branch = ss.branch if ss.branch else "master"
+    return branch != "try"
+
+gh = GitHubStatus(
     token=GITHUB_STATUS_TOKEN,
     repoOwner="servo",
     repoName="servo",
     startDescription="Build started",
     endDescription="Build complete"
-))
+)
+
+conditional_patch(gh, "buildStarted", ["builderName", "build"])
+conditional_patch(gh, "buildFinished", [
+    "builderName", "build", "results"
+])
+c['status'].append(gh)
 
 ####### PROJECT IDENTITY
 c['title'] = "Servo"


### PR DESCRIPTION
You can now edit the `conditional_status` function in `master.cfg`
to tell it which branches you should filter updates for.

```
modified:   buildbot/master/master.cfg
```

refs #5 
