### PR TITLE
Move the documentation builder to the android slave.

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -181,7 +181,7 @@ c['builders'].append(BuilderConfig(
 ))
 c['builders'].append(BuilderConfig(
     name="doc",
-    slavenames=[LINUX_SLAVES[0]],
+    slavenames=[ANDROID_SLAVES[0]],
     factory=doc_factory,
 ))
 


### PR DESCRIPTION
While the documentation is being built, all other slaves can start building
the next PR. Since the android build is currently much shorter than the linux
builds, it can start later (once the documentation build is finished) and
still finish before the other builds. This reduces the end-to-end time by
two or three minutes if there is a queue of pending PRs.
