### PR TITLE
Revert "Move the documentation builder to the android slave."

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -181,7 +181,7 @@ c['builders'].append(BuilderConfig(
 ))
 c['builders'].append(BuilderConfig(
     name="doc",
-    slavenames=[ANDROID_SLAVES[0]],
+    slavenames=[LINUX_SLAVES[0]],
     factory=doc_factory,
 ))
 


### PR DESCRIPTION
Reverts servo/saltfs#7.

Looks like that broke the build: http://build.servo.org/builders/doc/builds/567/steps/shell/logs/stdio.
