### PR TITLE
Ask WPT to look for a release build

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -166,7 +166,8 @@ linux1_factory_rel = BuildFactory()
 linux1_factory_rel.addStep(Git(repourl=SERVO_REPO, mode="full", method="clobber"))
 linux1_factory_rel.addStep(ShellCommand(command=["./mach", "test-tidy"], env=linux_headless_env))
 linux1_factory_rel.addStep(Compile(command=["./mach", "build", "--release"], env=linux_headless_env))
-linux1_factory_rel.addStep(ShellCommand(command=["./mach", "test-unit"], env=linux_headless_env))
+# https://github.com/rust-lang/cargo/issues/691
+# linux1_factory_rel.addStep(ShellCommand(command=["./mach", "test-unit"], env=linux_headless_env))
 linux1_factory_rel.addStep(ShellCommand(command=["./mach", "test-content"], env=linux_headless_env))
 linux1_factory_rel.addStep(ShellCommand(command=["./mach", "test-ref", "--kind", "cpu"],
                                     env=linux_headless_env))
@@ -177,7 +178,7 @@ linux2_factory_rel.addStep(Git(repourl=SERVO_REPO, mode="full", method="clobber"
 linux2_factory_rel.addStep(Compile(command=["./mach", "build", "--release"], env=linux_test_env))
 linux2_factory_rel.addStep(ShellCommand(command=["./mach", "test-wpt-failure"],
                                     env=linux_test_env))
-linux2_factory_rel.addStep(ShellCommand(command=["./mach", "test-wpt", "--processes", "4"],
+linux2_factory_rel.addStep(ShellCommand(command=["./mach", "test-wpt", "--release", "--processes", "4"],
                                     env=linux_test_env))
 linux2_factory_rel.addStep(Compile(command=["./mach", "build-cef", "--release"]))
 
@@ -187,9 +188,10 @@ mac1_factory_rel.addStep(ShellCommand(command=["./mach", "test-tidy"]))
 mac1_factory_rel.addStep(Compile(command=["./mach", "build", "--release"]))
 mac1_factory_rel.addStep(ShellCommand(command=["./mach", "test-wpt-failure"],
                                   env=common_test_env))
-mac1_factory_rel.addStep(ShellCommand(command=["./mach", "test-wpt", "--processes", "4", "--total-chunks", "2", "--this-chunk", "1"],
+mac1_factory_rel.addStep(ShellCommand(command=["./mach", "test-wpt", "--release", "--processes", "4", "--total-chunks", "2", "--this-chunk", "1"],
                                  env=common_test_env))
-mac1_factory_rel.addStep(ShellCommand(command=["./mach", "test-unit"], env=common_test_env))
+# https://github.com/rust-lang/cargo/issues/691
+# mac1_factory_rel.addStep(ShellCommand(command=["./mach", "test-unit"], env=common_test_env))
 mac1_factory_rel.addStep(Compile(command=["./mach", "build-cef"]))
 
 mac2_factory_rel = BuildFactory()


### PR DESCRIPTION
Needs https://github.com/servo/servo/pull/5074 first

I also disabled test-unit since it will rebuild everything in nopt mode until https://github.com/rust-lang/cargo/issues/691 gets fixed

test-ref and test-content need --release support too, I'll add (or E-Easy) those soon.