### PR TITLE
Move SERVO_CACHE_DIR outside of src dir

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -88,10 +88,17 @@ common_test_env = {
     'RUST_BACKTRACE': '1'
 }
 
-linux_test_env = dict({'DISPLAY': ':0', 'CARGO_HOME': '/home/servo/.cargo'}, **common_test_env)
+linux_test_env = dict({
+    'DISPLAY': ':0',
+    'CARGO_HOME': '/home/servo/.cargo',
+    'SERVO_CACHE_DIR': '/home/servo/.servo'
+}, **common_test_env)
 linux_headless_env = dict({'SERVO_HEADLESS': '1'}, **linux_test_env)
 
-mac_test_env = dict({'CARGO_HOME': '/Users/servo/.cargo'}, **common_test_env)
+mac_test_env = dict({
+    'CARGO_HOME': '/Users/servo/.cargo'
+    'SERVO_CACHE_DIR': '/Users/servo/.servo'
+}, **common_test_env)
 
 linux1_factory = BuildFactory()
 linux1_factory.addStep(Git(repourl=SERVO_REPO, mode="full", method="clobber"))
@@ -157,7 +164,8 @@ gonk_factory.addStep(Compile(command=["./mach", "build-gonk"], env=gonk_compile_
 doc_factory = BuildFactory()
 doc_factory.addStep(Git(repourl=SERVO_REPO, mode="full", method="clobber"))
 doc_factory.addStep(ShellCommand(command=["etc/ci/upload_docs.sh"],
-                                 env={'TOKEN': GITHUB_DOC_TOKEN, 'CARGO_HOME': '/home/servo/.cargo'},
+                                 env={'TOKEN': GITHUB_DOC_TOKEN, 'CARGO_HOME': '/home/servo/.cargo',
+                                      'SERVO_CACHE_DIR': '/home/servo/.servo'},
                                  logEnviron=False)) # important not to leak token
 
 


### PR DESCRIPTION
This prevents our builders from re-downloading the rust/cargo snapshots every time.  Depends on servo/servo#5200.  r? @metajack or @larsbergstrom or @Manishearth