### PR TITLE
Add gperf, which is apparently needed by freetype-sys in some cases.

### DIFF
--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -44,6 +44,9 @@ xpra:
 libosmesa6-dev:
   pkg.installed
 
+gperf:
+  pkg.installed
+
 {% else %}
 
 pkg-config:


### PR DESCRIPTION
r? @edunham 