### PR TITLE
Add html5ever repo support to homu.

### DIFF
--- a/homu/cfg.toml
+++ b/homu/cfg.toml
@@ -11,49 +11,37 @@ app_client_id = "{{ pillar["homu"]["app-client-id"] }}"
 app_client_secret = "{{ pillar["homu"]["app-client-secret"] }}"
 
 [web]
-
-# The port homu listens on
 port = 54856
 
-# An example configuration for repository (there can be many of these)
-[repo.servo]
+{% set repos = [('servo', 'html5ever')] %}
+{% set reviewers = ["glennw","jdm","kmcallister","larsbergstrom","Manishearth","metajack","mbrubeck","Ms2ger","pcwalton","SimonSapin","mrobinson","brunoabinader","saneyuki","nox"] %}
 
-# github.com/<owner>/<name>
+[repo.servo]
 owner = "servo"
 name = "servo"
-
-# who has r+ rights?
-reviewers = ["glennw","jdm","kmcallister","larsbergstrom","Manishearth","metajack","mbrubeck","Ms2ger","pcwalton","SimonSapin","mrobinson","brunoabinader","saneyuki","nox"]
-
-## branch names (these settings here are the defaults)
-#[repo.NAME.branch]
-#
-#master = "master"
-#auto = "auto"
-#try = "try"
-#tmp = "tmp"
-#rollup = "rollup"
+reviewers = {{ reviewers }}
 
 [repo.servo.github]
-
-# arbitrary secret (e.g. openssl rand -hex 20)
 secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 
-## Use buildbot for running tests
 [repo.servo.buildbot]
-
 url = "http://build.servo.org"
 secret = "{{ pillar["homu"]["buildbot-secret"] }}"
-
 builders = ["linux1", "linux2", "linux3", "android", "mac1", "mac2", "gonk"]
 try_builders = ["linux1", "linux2", "linux3", "android", "mac1", "mac2", "gonk"]
-
-#
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 
-## Use travis for running tests
-#[repo.NAME.travis]
-#
-## found under <https://travis-ci.org/profile/info>.
-#token = ""
+{% for repo in repos %}
+[repo.{{ repo[1] }}]
+owner = "{{ repo[0] }}"
+name = "{{ repo[1] }}"
+reviewers = {{ reviewers }}
+
+[repo.{{ repo[1] }}.github]
+secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
+
+[repo.{{ repo[1] }}.travis]
+token = "{{ pillar["homu"]["travis-ci-token"] }}"
+
+{% endfor %}


### PR DESCRIPTION
To enable repos you have to:

1) Add them in the homu/cfg.toml by adding to the list as ('$owner', '$repo')
2) Add a webhook for http://build.servo.org:54856/github to the repo webhooks for push,pull request, and issue comments with the secret key (see private data pillar for the key)
3) Add a webhook in `.travis.yml` in the repo pointing at http://build.servo.org:54856/travis

Additionally you may need to reset the travis token and associated user in the travis service in the github admin panel for the repo. (use bors-servo as the user).