### PR TITLE
Let's test configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+python:
+- '2.7'
+
+before_install:
+  - sudo apt-get update
+  - curl -L http://bootstrap.saltstack.org | sudo sh -s -- git develop
+
+install:
+  # Copy these states
+  - sudo mkdir -p /srv/salt/states
+  - sudo cp -r . /srv/salt/states
+  - sudo cp .travis/minion /etc/salt/minion
+  - sudo service salt-minion restart
+
+  # Additional debug help
+  - sudo cat /var/log/salt/*
+
+  # See what kind of travis box you're on
+  # to help with making your states compatible with travis
+  - sudo salt-call grains.items --local
+
+script:
+  - sudo salt-call state.show_highstate --local  --retcode-passthrough

--- a/.travis/minion
+++ b/.travis/minion
@@ -1,0 +1,4 @@
+file_client: local
+file_roots:
+  base:
+    - /srv/salt/states


### PR DESCRIPTION
https://lambdaops.com/automation/travis/travis%20ci/configuration%20management/continuous%20integration/salt/chef/saltstack/salt%20stack/2014/01/29/travis-for-salt-states/
claims that this configuration works for basic validation of salt errors.

It should at least catch typos before they get to production.

This is what we discussed over at https://github.com/servo/saltfs/pull/39#issuecomment-110508071

r? @metajack 