### PR TITLE
Run WPT against the release binaries, so that IPC servo can land

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -141,15 +141,15 @@ linux1_factory.addStep(steps.ShellCommand(command=["./mach", "test-ref", "--kind
 
 linux2_factory = util.BuildFactory()
 linux2_factory.addStep(steps.Git(repourl=SERVO_REPO, mode="full", method="clobber"))
-linux2_factory.addStep(steps.Compile(command=["./mach", "build", "--dev"], env=linux_headless_env))
+linux2_factory.addStep(steps.Compile(command=["./mach", "build", "--release"], env=linux_headless_env))
 linux2_factory.addStep(steps.ShellCommand(command=["./mach", "test-wpt-failure"],
                                           env=linux_headless_env))
-linux2_factory.addStep(steps.ShellCommand(command=["./mach", "test-wpt", "--processes", "4",
+linux2_factory.addStep(steps.ShellCommand(command=["./mach", "test-wpt", "--release", "--processes", "4",
                                                    "--log-raw", "wpt_raw.log"],
                                           env=linux_headless_env,
                                           logfiles={"wpt_raw.log": "wpt_raw.log"}))
 linux2_factory.addStep(steps.ShellCommand(command=["gzip", "wpt_raw.log"], env=linux_headless_env))
-linux2_factory.addStep(steps.Compile(command=["./mach", "build-cef"], env=linux_headless_env))
+linux2_factory.addStep(steps.Compile(command=["./mach", "build-cef", "--release"], env=linux_headless_env))
 
 linux3_factory = util.BuildFactory()
 linux3_factory.addStep(steps.Git(repourl=SERVO_REPO, mode="full", method="clobber"))
@@ -166,10 +166,10 @@ task_limited_test_env = dict({'RUST_TEST_TASKS': '1'}, **mac_test_env)
 mac1_factory = util.BuildFactory()
 mac1_factory.addStep(steps.Git(repourl=SERVO_REPO, mode="full", method="clobber"))
 mac1_factory.addStep(steps.ShellCommand(command=["./mach", "test-tidy"]))
-mac1_factory.addStep(steps.Compile(command=["./mach", "build", "--dev"], env=mac_test_env))
+mac1_factory.addStep(steps.Compile(command=["./mach", "build", "--release"], env=mac_test_env))
 mac1_factory.addStep(steps.ShellCommand(command=["./mach", "test-wpt-failure"],
                                   env=mac_test_env))
-mac1_factory.addStep(steps.ShellCommand(command=["./mach", "test-wpt", "--processes", "4",
+mac1_factory.addStep(steps.ShellCommand(command=["./mach", "test-wpt", "--release", "--processes", "4",
                                            "--log-raw", "wpt_raw.log"],
                                   env=mac_test_env,
                                   logfiles={"wpt_raw.log": "wpt_raw.log"}))


### PR DESCRIPTION
r? @edunham 

This change makes our web platform tests run against a release build of servo instead of debug, so that @pcwalton's IPC servo changes can land.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/83)
<!-- Reviewable:end -->
