### PR TITLE
Install msttcorefonts on Linux buildbot machines

### DIFF
--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -32,6 +32,9 @@ libssl-dev:
 libbz2-dev:
   pkg.installed
 
+msttcorefonts:
+  pkg.installed
+
 xserver-xorg-input-void:
   pkg.installed
 


### PR DESCRIPTION
Some of the CSS tests depend on these fonts.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/111)
<!-- Reviewable:end -->
