### PR TITLE
Use correct package name for mscorefonts

### DIFF
--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -44,7 +44,7 @@ libssl-dev:
 libbz2-dev:
   pkg.installed
 
-msttcorefonts:
+ttf-mscorefonts-installer:
   pkg.installed
 
 xserver-xorg-input-void:


### PR DESCRIPTION
Salt has some bug with virtual package names, so it failed mysteriously
when it was msttcorefonts.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/117)
<!-- Reviewable:end -->
