### PR TITLE
Add a dependency on autoconf-2.13

### DIFF
--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -19,6 +19,7 @@ servo-dependencies:
       - git
       {% if grains['kernel'] == 'Darwin' %}
       - pkg-config
+      - homebrew/versions/autoconf213
       {% else %}
       - libglib2.0-dev
       - libgl1-mesa-dri
@@ -33,6 +34,7 @@ servo-dependencies:
       - xpra
       - libosmesa6-dev
       - gperf
+      - autoconf2.13
       {% endif %}
   pip.installed:
     - pkgs:


### PR DESCRIPTION
This is necessary for https://github.com/servo/mozjs/pull/56 which runs autoconf at build time instead of checking in configure.

No idea if this will work on osx..

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/122)
<!-- Reviewable:end -->
