### PR TITLE
Kill Servo processes left around

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -2,6 +2,7 @@
 # ex: set syntax=python:
 
 from buildbot.plugins import *
+from buildbot.status.results import SUCCESS
 
 from passwords import HTTP_USERNAME, HTTP_PASSWORD, SLAVE_PASSWORD, CHANGE_PASSWORD
 from passwords import GITHUB_DOC_TOKEN, GITHUB_STATUS_TOKEN, HOMU_BUILDBOT_SECRET
@@ -191,10 +192,12 @@ linux_rel_factory = create_servo_factory([
     steps.ShellCommand(command=["./mach", "test-wpt", "--release", "--processes", "24",
                                 "--log-raw", "test-wpt.log"],
                        env=linux_headless_env, logfiles={"test-wpt.log": "test-wpt.log"}),
+    steps.ShellCommand(command=["pkill", "-x", "servo"], decodeRC={0: SUCCESS, 1: SUCCESS}),
     steps.ShellCommand(command=["gzip", "test-wpt.log"], env=linux_headless_env),
     steps.ShellCommand(command=["./mach", "test-css", "--release", "--processes", "24",
                                 "--log-raw", "test-css.log"],
                        env=linux_headless_env, logfiles={"test-css.log": "test-css.log"}),
+    steps.ShellCommand(command=["pkill", "-x", "servo"], decodeRC={0: SUCCESS, 1: SUCCESS}),
     steps.ShellCommand(command=["gzip", "test-css.log"], env=linux_headless_env),
     steps.Compile(command=["./mach", "build-cef", "--release"], env=linux_headless_env),
 ])
@@ -208,6 +211,7 @@ mac_rel_wpt_factory = create_servo_factory([
     steps.ShellCommand(command=["./mach", "test-wpt", "--release", "--processes", "4",
                                 "--log-raw", "test-wpt.log"],
                        env=mac_test_env, logfiles={"test-wpt.log": "test-wpt.log"}),
+    steps.ShellCommand(command=["pkill", "-x", "servo"], decodeRC={0: SUCCESS, 1: SUCCESS}),
     steps.ShellCommand(command=["gzip", "test-wpt.log"], env=mac_test_env),
 ])
 
@@ -224,6 +228,7 @@ mac_rel_css_factory = create_servo_factory([
     steps.ShellCommand(command=["./mach", "test-css", "--release", "--processes", "4",
                                 "--log-raw", "test-css.log"],
                        env=mac_test_env, logfiles={"test-css.log": "test-css.log"}),
+    steps.ShellCommand(command=["pkill", "-x", "servo"], decodeRC={0: SUCCESS, 1: SUCCESS}),
     steps.ShellCommand(command=["gzip", "test-css.log"], env=mac_test_env),
 ])
 


### PR DESCRIPTION
After running wpt tests, we sometimes end up with zombie servo processes
at 100% CPU. This kills those off to reset machine state.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/123)
<!-- Reviewable:end -->
