### PR TITLE
Add service_identity module

### DIFF
--- a/buildbot/master.sls
+++ b/buildbot/master.sls
@@ -1,6 +1,7 @@
 buildbot:
   pip.installed:
     - name: buildbot == 0.8.12
+    - name: service_identity == 14.0.0
 
 txgithub:
   pip.installed


### PR DESCRIPTION
Squashes the following warning when starting Buildbot:

2015-10-22 19:41:50+0000 [-]
/usr/local/lib/python2.7/dist-packages/twisted/internet/_sslverify.py:184:
exceptions.UserWarning: You do not have the service_identity module installed.
Please install it from <https://pypi.python.org/pypi/service_identity>.
Without the service_identity module and a recent enough pyOpenSSL tosupport
it, Twisted can perform only rudimentary TLS client hostnameverification.
Many valid certificate/hostname mappings may be rejected.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/132)
<!-- Reviewable:end -->
