### PR TITLE
Add a linode slave for fallback when EC2 is borked

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -12,6 +12,7 @@ from passwords import MINION_PUBLIC_KEY, MINION_PRIVATE_KEY
 SERVO_REPO = "https://github.com/servo/servo"
 HEAD_SLAVES = ["servo-head"]
 LINUX_SLAVES = ["linux1", "linux2"]
+LINUX_LINODE_SLAVES = ["servo-linux1"]
 MAC_SLAVES = ["servo-mac1", "servo-mac2", "servo-mac3"]
 ANDROID_SLAVES = ["servo-linux-android1"]
 
@@ -51,7 +52,7 @@ def make_user_data(s):
     return "\n".join(lines)
 
 c['slaves'] = []
-for s in MAC_SLAVES + ANDROID_SLAVES + HEAD_SLAVES:
+for s in MAC_SLAVES + ANDROID_SLAVES + HEAD_SLAVES + LINUX_LINODE_SLAVES:
     c['slaves'].append(buildslave.BuildSlave(s, SLAVE_PASSWORD, max_builds=1))
 for s in LINUX_SLAVES:
     c['slaves'].append(buildslave.EC2LatentBuildSlave(
@@ -311,14 +312,14 @@ def branch_priority(builder, requests):
 c['builders'] = []
 c['builders'].append(util.BuilderConfig(
     name="linux-dev",
-    slavenames=LINUX_SLAVES,
+    slavenames=LINUX_SLAVES + LINUX_LINODE_SLAVES,
     factory=linux_dev_factory,
     nextBuild=branch_priority,
     category="auto",
 ))
 c['builders'].append(util.BuilderConfig(
     name="linux-rel",
-    slavenames=LINUX_SLAVES,
+    slavenames=LINUX_SLAVES + LINUX_LINODE_SLAVES,
     factory=linux_rel_factory,
     nextBuild=branch_priority,
     category="auto",
@@ -374,7 +375,7 @@ c['builders'].append(util.BuilderConfig(
 ))
 c['builders'].append(util.BuilderConfig(
     name="cargo-linux",
-    slavenames=LINUX_SLAVES,
+    slavenames=LINUX_SLAVES + LINUX_LINODE_SLAVES,
     factory=cargo_linux_factory,
     nextBuild=branch_priority,
     category="cargo_auto"


### PR DESCRIPTION
r? @metajack @Manishearth @edunham 

Just added a linode 20 core instance to act as a backup until we can get the EC2 stuff settled out. It's been ~a month of super flaky EC2 builder and getting tired of that queue backing up.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/133)
<!-- Reviewable:end -->
