### PR TITLE
Explicitly install deps to fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 before_install:
   - sudo add-apt-repository -y ppa:saltstack/salt
   - sudo apt-get update
-  - sudo apt-get install salt-master salt-minion
+  - sudo apt-get install salt-common python-zmq dmidecode salt-master salt-minion
   - sudo mkdir -p /srv/salt/states
   - sudo cp .travis/minion /etc/salt/minion
 
@@ -14,7 +14,6 @@ install:
   - sudo cp -r . /srv/salt/states
   - sudo cp .travis/minion /etc/salt/minion
   - sudo service salt-minion restart
-
 
   # Additional debug help. May fail if run before Salt finishes restarting.
   # - sudo cat /var/log/salt/*


### PR DESCRIPTION
The logs at https://travis-ci.org/servo/saltfs/jobs/87759990, specifically

    The following packages have unmet dependencies:
     salt-minion : Depends: salt-common (= 2015.5.3+ds-1precise2) but it is not going to be installed
                   Depends: python-zmq (>= 13.0.0) but it is not going to be installed
                   Recommends: dmidecode but it is not going to be installed
    E: Unable to correct problems, you have held broken packages.
    The command ".travis/install_salt" failed and exited with 100 during .
    Your build has been stopped.

make me think that having those packages available on the system will allow the
build to continue. Maybe.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/138)
<!-- Reviewable:end -->
