### PR TITLE
Enable usage of the Trusty beta on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,33 @@
 language: cpp
 
 # NOTE: Make sure the matrix covers all node types in top.sls
+# sudo: required and dist: trusty enable usage of Trusty
 matrix:
   include:
-    - os: linux
-      env: SALT_NODE_ID=servo-master
-    - os: linux
-      env: SALT_NODE_ID=servo-linux1
-    - os: osx
-      env: SALT_NODE_ID=servo-mac1
-    - os: osx
-      env: SALT_NODE_ID=servo-macpro1
-    - os: linux
-      env: SALT_NODE_ID=linux1
-    - os: linux
-      env: SALT_NODE_ID=servo-linux-android1
-    - os: linux
-      env: SALT_NODE_ID=servo-head
+    - env: SALT_NODE_ID=servo-master
+      os: linux
+      sudo: required
+      dist: trusty
+    - env: SALT_NODE_ID=servo-linux1
+      os: linux
+      sudo: required
+      dist: trusty
+    - env: SALT_NODE_ID=servo-mac1
+      os: osx
+    - env: SALT_NODE_ID=servo-macpro1
+      os: osx
+    - env: SALT_NODE_ID=linux1
+      os: linux
+      sudo: required
+      dist: trusty
+    - env: SALT_NODE_ID=servo-linux-android1
+      os: linux
+      sudo: required
+      dist: trusty
+    - env: SALT_NODE_ID=servo-head
+      os: linux
+      sudo: required
+      dist: trusty
 
 before_install:
   - .travis/install_salt

--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -5,7 +5,7 @@
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
   printf "$0: installing salt for Linux\n"
   # Use Trusty (Ubuntu 14.04) on Travis
-  wget -O - https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+  curl https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
   printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14/2015.5 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
   sudo apt-get -y update
   sudo apt-get -y install salt-minion=2015.5.6+ds-1

--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -4,9 +4,9 @@
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
   printf "$0: installing salt for Linux\n"
-  # Travis uses Ubuntu 12.04 (Precise Pangolin)
-  wget -O - https://repo.saltstack.com/apt/ubuntu/ubuntu12/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-  printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu12/2015.5 precise main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
+  # Use Trusty (Ubuntu 14.04) on Travis
+  wget -O - https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+  printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14/2015.5 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
   sudo apt-get -y update
   sudo apt-get -y install salt-minion=2015.5.6+ds-1
 elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then


### PR DESCRIPTION
Travis now has new Trusty based instances in Beta. They offer much
faster boot times, twice as much memory, and a more reliable core count.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/144)
<!-- Reviewable:end -->
