### PR TITLE
Add Vagrantfile for local debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,24 +32,19 @@ matrix:
       dist: trusty
 
 before_install:
-  - .travis/install_salt
+  - .travis/install_salt "${TRAVIS_OS_NAME}"
 
 install:
-  - sudo mkdir -p /etc/salt
-  - sudo cp .travis/minion /etc/salt/minion
-
-  - sudo mkdir -p /srv/salt/states
-  - sudo cp -r . /srv/salt/states
+  - .travis/configure_salt
 
   # For debugging, check the grains reported by the Travis builder
   - sudo salt-call --id="${SALT_NODE_ID}" grains.items
 
 script:
-  # Use test pillars on Travis
   # Minimally validate YAML and Jinja at a basic level
-  - sudo salt-call --id="${SALT_NODE_ID}" --retcode-passthrough --pillar-root=.travis/test_pillars state.show_highstate
+  - sudo salt-call --id="${SALT_NODE_ID}" --retcode-passthrough state.show_highstate
   # Full on installation test
-  - sudo salt-call --id="${SALT_NODE_ID}" --retcode-passthrough --pillar-root=.travis/test_pillars state.highstate
+  - sudo salt-call --id="${SALT_NODE_ID}" --retcode-passthrough state.highstate
 
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/.travis/configure_salt
+++ b/.travis/configure_salt
@@ -1,0 +1,12 @@
+#/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+sudo mkdir -p /etc/salt
+sudo cp .travis/minion /etc/salt/minion
+
+sudo mkdir -p /srv/salt
+sudo cp -r . /srv/salt/states
+sudo cp -r .travis/test_pillars /srv/salt/pillars

--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+set -o pipefail
+
+if [[ "$#" < 1 ]]; then
+  printf >&2 "usage: $0 os_name\n"
+  exit 1
+fi
+
 # Ensure that pinned versions match as closely as possible
 
-if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+OS_NAME="$1"
+if [[ "${OS_NAME}" == "linux" ]]; then
   printf "$0: installing salt for Linux\n"
   # Use Trusty (Ubuntu 14.04) on Travis
   curl https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
   printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14/2015.5 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
   sudo apt-get -y update
   sudo apt-get -y install salt-minion=2015.5.6+ds-1
-elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+elif [[ "${OS_NAME}" == "osx" ]]; then
   printf "$0: installing salt for Mac OS X\n"
   brew update
   brew install https://raw.githubusercontent.com/Homebrew/homebrew/86efec6695b019762505be440798c46d50ebd738/Library/Formula/saltstack.rb
 else
-  printf >&2 "$0: environment variable TRAVIS_OS_NAME not set or set to unknown value\n"
+  printf >&2 "$0: unknown operating system ${OS_NAME}\n"
   exit 1
 fi

--- a/.travis/minion
+++ b/.travis/minion
@@ -2,3 +2,6 @@ file_client: local
 file_roots:
   base:
     - /srv/salt/states
+pillar_roots:
+  base:
+    - /srv/salt/pillars

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,47 @@
+require 'yaml'
+
+def extract_id(env)
+  id = env.split.map do |env_var|
+    env_var[/^SALT_NODE_ID=(?<node_id>.+)$/, "node_id"]
+  end.compact
+  id[0]
+end
+
+Vagrant.configure(2) do |config|
+
+  YAML.load_file('.travis.yml')['matrix']['include'].map do |node|
+    node_config = case node['os']
+    when 'linux'
+      case node['dist']
+      when 'trusty'
+        { id: extract_id(node['env']), os: node['os'], box: 'ubuntu/trusty64' }
+      end
+    end
+    if node_config.nil? && ENV['VAGRANT_LOG'] == 'debug'
+      version = node.has_key?('dist') ? ', version' + node['dist'] : ''
+      os_and_version = node['os'] + version
+      puts "OS #{os_and_version} is not yet supported"
+    else
+      node_config
+    end
+  end.compact.each do |node|
+    config.vm.define node[:id] do |machine|
+      machine.vm.box = node[:box]
+      machine.vm.synced_folder ".",  "/srv/salt/states"
+      machine.vm.synced_folder ".travis/test_pillars", "/srv/salt/pillars"
+      machine.vm.provision :salt do |salt|
+        salt.bootstrap_script = '.travis/install_salt'
+        salt.install_command = node[:os] # Pass OS type to install_salt script
+        salt.masterless = true
+        salt.minion_config = '.travis/minion'
+        # hack to provide additional options to salt-call
+        salt.minion_id = node[:id] + ' --retcode-passthrough'
+        salt.run_highstate = true
+        salt.verbose = true
+        salt.log_level = 'info'
+        salt.colorize = true
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Add a Vagrantfile that is mostly auto-generated from .travis.yml.
Meant to be used for local debugging.
Creates a multiple-machine setup with one machine for each supported
node type, and runs the highstate as the provision step.

Note: currently doesn't work due to bugs in the vagrant salt
provisioner, which I have put PRs in to fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/147)
<!-- Reviewable:end -->
