### PR TITLE
Add the new packaging step to the nightly builder

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -244,8 +244,9 @@ android_factory = create_servo_factory([
 
 android_nightly_factory = create_servo_factory([
     steps.Compile(command=["./mach", "build", "--android", "--release"], env=android_compile_env),
+    steps.Compile(command=["./mach", "package", "-r"], env=android_compile_env),
     steps.ShellCommand(command=["s3cmd", "put",
-                                "/home/servo/buildbot/slave/android-nightly/build/target/arm-linux-androideabi/release/servo",
+                                "/home/servo/buildbot/slave/android-nightly/build/target/arm-linux-androideabi/release/servo.apk",
                                 "s3://servo-rust/nightly/servo.apk"]),
 ])
 


### PR DESCRIPTION
This should wait for https://github.com/servo/servo/pull/8288 to land; I'll ping the review then.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/154)
<!-- Reviewable:end -->
