### PR TITLE
Wrap shell scripts for safety

### DIFF
--- a/.travis/configure_salt
+++ b/.travis/configure_salt
@@ -1,12 +1,15 @@
-#/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -e
-set -u
-set -o pipefail
+configure_salt () {
+    set -o errexit
+    set -o nounset
 
-sudo mkdir -p /etc/salt
-sudo cp .travis/minion /etc/salt/minion
+    sudo mkdir -p /etc/salt
+    sudo cp .travis/minion /etc/salt/minion
 
-sudo mkdir -p /srv/salt
-sudo cp -r . /srv/salt/states
-sudo cp -r .travis/test_pillars /srv/salt/pillars
+    sudo mkdir -p /srv/salt
+    sudo cp -r . /srv/salt/states
+    sudo cp -r .travis/test_pillars /srv/salt/pillars
+}
+
+configure_salt "$@"

--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -1,29 +1,31 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -e
-set -u
-set -o pipefail
+install_salt () {
+    set -o errexit
+    set -o nounset
 
-if [[ "$#" < 1 ]]; then
-  printf >&2 "usage: $0 os_name\n"
-  exit 1
-fi
+    if [ "$#" -lt 1 ]; then
+        printf >&2 "usage: $0 os_name\n"
+        exit 1
+    fi
+    OS_NAME="$1"
 
-# Ensure that pinned versions match as closely as possible
+    # Ensure that pinned versions match as closely as possible
+    if [ "${OS_NAME}" = "linux" ]; then
+        printf "$0: installing salt for Linux\n"
+        # Use Trusty (Ubuntu 14.04) on Travis
+        curl https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+        printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14/2015.5 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
+        sudo apt-get -y update
+        sudo apt-get -y install salt-minion=2015.5.6+ds-1
+    elif [ "${OS_NAME}" = "osx" ]; then
+        printf "$0: installing salt for Mac OS X\n"
+        brew update
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew/86efec6695b019762505be440798c46d50ebd738/Library/Formula/saltstack.rb
+    else
+        printf >&2 "$0: unknown operating system ${OS_NAME}\n"
+        exit 1
+    fi
+}
 
-OS_NAME="$1"
-if [[ "${OS_NAME}" == "linux" ]]; then
-  printf "$0: installing salt for Linux\n"
-  # Use Trusty (Ubuntu 14.04) on Travis
-  curl https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-  printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14/2015.5 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
-  sudo apt-get -y update
-  sudo apt-get -y install salt-minion=2015.5.6+ds-1
-elif [[ "${OS_NAME}" == "osx" ]]; then
-  printf "$0: installing salt for Mac OS X\n"
-  brew update
-  brew install https://raw.githubusercontent.com/Homebrew/homebrew/86efec6695b019762505be440798c46d50ebd738/Library/Formula/saltstack.rb
-else
-  printf >&2 "$0: unknown operating system ${OS_NAME}\n"
-  exit 1
-fi
+install_salt "$@"


### PR DESCRIPTION
Wrap the entirety of the install_salt and configure_salt shell scripts
in a function to prevent problems if interrupted mid-download, as
preparation to update the installation guide in the wiki to use these
scripts via curl | sudo sh.

Also make scripts portable and do a bit of cleanup.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/155)
<!-- Reviewable:end -->
