### PR TITLE
Update to Salt 2015.5.8

### DIFF
--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -14,10 +14,10 @@ install_salt () {
     if [ "${OS_NAME}" = "linux" ]; then
         printf "$0: installing salt for Linux\n"
         # Use Trusty (Ubuntu 14.04) on Travis
-        curl https://repo.saltstack.com/apt/ubuntu/ubuntu14/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-        printf 'deb http://repo.saltstack.com/apt/ubuntu/ubuntu14/2015.5 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
+        curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
         sudo apt-get -y update
-        sudo apt-get -y install salt-minion=2015.5.6+ds-1
+        sudo apt-get -y install salt-minion=2015.5.8+ds-1
     elif [ "${OS_NAME}" = "osx" ]; then
         printf "$0: installing salt for Mac OS X\n"
         brew update


### PR DESCRIPTION
Also switch to new archive url scheme (introduced with 2015.8.3).
The new archive urls point to a specific Salt version and will not
change over time, allowing for precise version pinning.

Closes #174.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/175)
<!-- Reviewable:end -->
