### PR TITLE
Allocate extra memory for Vagrant VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,10 @@ Vagrant.configure(2) do |config|
   end.compact.each do |node|
     config.vm.define node[:id] do |machine|
       machine.vm.box = node[:box]
+      machine.vm.provider :virtualbox do |vbox|
+         # Need extra memory for downloading large files (e.g. Android SDK)
+         vbox.memory = 1024
+      end
       machine.vm.synced_folder dir, state_root
       machine.vm.synced_folder File.join(dir, ".travis/test_pillars"), pillar_root
       machine.vm.provision :salt do |salt|


### PR DESCRIPTION
Provide more memory for VMs that download large files (e.g. the Android
SDK and NDK) to stop salt-call from getting OOM-killed inside the VM.
This makes it possible to test all node types locally with Vagrant.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/176)
<!-- Reviewable:end -->
