### PR TITLE
[DO NOT MERGE] Update to Salt 2015.8.1

### DIFF
--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -14,14 +14,14 @@ install_salt () {
     if [ "${OS_NAME}" = "linux" ]; then
         printf "$0: installing salt for Linux\n"
         # Use Trusty (Ubuntu 14.04) on Travis
-        curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
+        curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.1/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.1 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
         sudo apt-get -y update
-        sudo apt-get -y install salt-minion=2015.5.8+ds-1
+        sudo apt-get -y install salt-minion=2015.8.1+ds-1
     elif [ "${OS_NAME}" = "osx" ]; then
         printf "$0: installing salt for Mac OS X\n"
         brew update
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew/86efec6695b019762505be440798c46d50ebd738/Library/Formula/saltstack.rb
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew/74bc5ef500fe2242258b672a5e96c5429fc4792f/Library/Formula/saltstack.rb
     else
         printf >&2 "$0: unknown operating system ${OS_NAME}\n"
         exit 1

--- a/android-dependencies.sls
+++ b/android-dependencies.sls
@@ -31,7 +31,8 @@ android-sdk:
     - source: http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
     - source_hash: sha512=96fb71d78a8c2833afeba6df617edcd6cc4e37ecd0c3bec38c39e78204ed3c2bd54b138a56086bf5ccd95e372e3c36e72c1550c13df8232ec19537da93049284
     - archive_format: tar
-    - archive_user: servo # 2015.8 moves these to the standard user and group parameters
+    - user: servo
+    - group: servo
     - if_missing: /home/servo/android-sdk_r24.4.1-linux.tgz
   cmd.wait:
     # The arguments to --filter are from running 'android list sdk'


### PR DESCRIPTION
This update also removes usage of deprecated options, so these states will not work properly on 2015.5. (The run will attempt to succeed with an exit code of 0, but with a warning that reflects the broken state.) Hence, it is important that the the Salt installations in production are updated when these states are deployed.

Blocked on #165.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/178)
<!-- Reviewable:end -->
