### PR TITLE
Enable new linked clones feature for Vagrant 1.8.0+

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,8 +37,11 @@ Vagrant.configure(2) do |config|
     config.vm.define node[:id] do |machine|
       machine.vm.box = node[:box]
       machine.vm.provider :virtualbox do |vbox|
-         # Need extra memory for downloading large files (e.g. Android SDK)
-         vbox.memory = 1024
+        # Need extra memory for downloading large files (e.g. Android SDK)
+        vbox.memory = 1024
+        if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+          vbox.linked_clone = true
+        end
       end
       machine.vm.synced_folder dir, state_root
       machine.vm.synced_folder File.join(dir, ".travis/test_pillars"), pillar_root


### PR DESCRIPTION
Vagrant 1.8.0 introduced the new linked clones feature for much faster
initial imports. However, it is not on by default, so enable it if the
Vagrant version is high enough to support it. (Older versions of Vagrant
will error out on seeing the unknown-to-them linked_clone attribute.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/181)
<!-- Reviewable:end -->
