### PR TITLE
Add libgles2-mesa-dev to the list of servo dependencies

### DIFF
--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -43,6 +43,7 @@ servo-dependencies:
       {% else %}
       - libglib2.0-dev
       - libgl1-mesa-dri
+      - libgles2-mesa-dev
       - freeglut3-dev
       - libfreetype6-dev
       - xorg-dev


### PR DESCRIPTION
This will allow linux running over EGL instead of GLX (see
https://github.com/servo/servo/issues/7484), and is currently blocking
https://github.com/servo/servo/pull/9044, even though it can be worked
out.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/182)
<!-- Reviewable:end -->
