### PR TITLE
Update AMI ID for Linux slaves

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -59,7 +59,7 @@ for s in LINUX_SLAVES:
         s, SLAVE_PASSWORD, "c4.8xlarge",
         max_builds=1,
         build_wait_timeout=60*60,
-        ami="ami-01020a31",
+        ami="ami-1b8c957a",
         region="us-west-2",
         identifier=AWS_ACCESS_KEY,
         secret_identifier=AWS_SECRET_KEY,


### PR DESCRIPTION
Workflow for switching from Daala AWS account to Servo AWS account: 
- [x] Create Buildbot user in Servo account, download its creds, and set up its security groups to match Buildbot user in Daala account
- [x] Copy the buildslave AMI (originally private to the Daala account) to the Servo account (though this changes its ID)
- [x] PR to change all instances of Daala account's copy of the buildslave AMI ID to the Servo account's copy (that's this) 
- [ ] Land PR, update `/srv/pillar/buildbot.sls` `aws-access-key` and `aws-secret-key` to correspond to Servo AWS account's Buildbot user (carefully not running Salt in between these steps)
- [ ] Run Salt on servo-master to deploy changes
- [ ] Fix whatever all this broke
- [ ] Update the wiki

In other words, I'll merge this one by hand at the right time after r+ :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/183)
<!-- Reviewable:end -->
