### PR TITLE
Hack to add more latent builders in case of ill-timed restart

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -11,8 +11,8 @@ from passwords import MINION_PUBLIC_KEY, MINION_PRIVATE_KEY
 
 SERVO_REPO = "https://github.com/servo/servo"
 HEAD_SLAVES = ["servo-head"]
-LINUX_SLAVES = ["linux1", "linux2"]
-LINUX_LINODE_SLAVES = ["servo-linux1"]
+LINUX_SLAVES = ["linux1", "linux2", "linux3", "linux4", "linux5"]
+LINUX_LINODE_SLAVES = []
 MAC_SLAVES = ["servo-mac1", "servo-mac2", "servo-mac3"]
 ANDROID_SLAVES = ["servo-linux-android1"]
 


### PR DESCRIPTION
We should never have more than two active, but when one builder "dies" for w/e reason, for the duration of the buildbot run, the machine will not be restarted. This adds 3, getting us to 5, an arbitrary number that I hope will keep us at our 2 live instances at any point in time until we can either pull the trigger on reserved instances or get better about Graceful Shutdown, etc.

Also, removed `servo-linux1`, which is no longer around but was still on the waterfall page.

r? @edunham @metajack @Manishearth

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/195)
<!-- Reviewable:end -->
