### PR TITLE
Remove 5-day-old zipped logs from buildslave dirs every night

### DIFF
--- a/buildbot/master.sls
+++ b/buildbot/master.sls
@@ -51,3 +51,10 @@ buildbot-github-listener:
     - watch:
       - file: /usr/local/bin/github_buildbot.py
       - file: /etc/init/buildbot-github-listener.conf
+
+remove-old-build-logs:
+  cron.present:
+    - name: 'find /home/servo/buildbot/master/*/*.bz2 -mtime +5 -delete'
+    - user: root
+    - minute: 1 
+    - hour: 0


### PR DESCRIPTION
Low disk space command from https://github.com/servo/servo/wiki/Buildbot-administration#handling-low-disk-space . We should no longer need to escape the semicolon, since Bash eats semicolons but Salt doesn't (right?)

Salt cron syntax from https://docs.saltstack.com/en/latest/ref/states/all/salt.states.cron.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/200)
<!-- Reviewable:end -->
