### PR TITLE
fix NDK version path

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -246,7 +246,7 @@ mac_rel_css_factory = create_servo_factory([
 ])
 
 android_compile_env = dict({'ANDROID_SDK': '/home/servo/android-sdk-linux/',
-                            'ANDROID_NDK': '/home/servo/android-ndk-r10c/',
+                            'ANDROID_NDK': '/home/servo/android-ndk-r10e/',
                             'ANDROID_TOOLCHAIN': '/home/servo/ndk-toolchain/',
                             'PATH': '/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin:/home/servo/android-sdk-linux/platform-tools:/home/servo/ndk-toolchain/bin'},
                            **linux_test_env)
@@ -265,7 +265,7 @@ android_nightly_factory = create_servo_factory([
 ])
 
 gonk_compile_env = dict({'ANDROID_SDK': '/home/servo/android-sdk-linux/',
-                         'ANDROID_NDK': '/home/servo/android-ndk-r10c/',
+                         'ANDROID_NDK': '/home/servo/android-ndk-r10e/',
                          'ANDROID_TOOLCHAIN': '/home/servo/ndk-toolchain/',
                          'GONKDIR': '/home/servo/B2G/',
                          'PATH': '/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin:/home/servo/B2G/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.7/bin'},


### PR DESCRIPTION
r? @metajack @Manishearth 

We had updated the Salt stuff to install r10e instead of r10c, but not the environment variables. This happens to work on older builders that still had r10c on them. Did not work on servo-head (which is a second reason why android-nightly has been failing).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/203)
<!-- Reviewable:end -->
