### PR TITLE
Link autoconf after installing autoconf213 on OS X

### DIFF
--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -30,6 +30,20 @@ servo-darwin-homebrew-versions-dependencies:
       - homebrew/versions
     - require_in:
       - pkg: servo-dependencies
+
+homebrew-link-autoconf:
+  cmd.run:
+    - name: 'brew link --overwrite autoconf'
+    - user: administrator
+      # Warning: Only checks that some autoconf Homebrew package is linked,
+      # not necessarily the version installed above.
+      # Whether this handles updating autoconf properly is an open question.
+      # This state should be replaced by a custom Salt state.
+    - creates: /usr/local/Library/LinkedKegs/autoconf
+    - require:
+      - module: servo-darwin-homebrew-versions-dependencies
+    - require_in:
+      - pkg: servo-dependencies
 {% endif %}
 
 servo-dependencies:


### PR DESCRIPTION
This needs to be tested manually on one of the Mac builders before merging.

Use --overwrite because autoconf and autoconf213 are installed, and
either one may have been linked beforehand. They overlap in the files
they provide, and Homebrew will refuse to destructively overwrite
any symlinks without an explicit flag.

There's no built-in Salt module for brew link, so for now this is a
quick fix. This provides some idempotence for repeated Salt highstate
runs by checking the directory where Homebrew keeps track of linked
packages (and linking autoconf if it is not linked). It's unknown
whether this approach properly handles updates to one or both packages.

A better approach would be to write a custom Salt state (perhaps
homebrew.linked); even if this state works properly, a custom state
would be more declarative and could be upstreamed to Salt proper.

Closes servo/servo#9504.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/211)
<!-- Reviewable:end -->
