### PR TITLE
Link a newer openssl from homebrew on OS X

### DIFF
--- a/.travis/test_pillars/travis.sls
+++ b/.travis/test_pillars/travis.sls
@@ -1,1 +1,4 @@
 travis: True
+
+homebrew:
+  user: travis

--- a/map.jinja
+++ b/map.jinja
@@ -1,0 +1,10 @@
+{%
+  set homebrew = salt['grains.filter_by']({
+      'defaults': {},
+      'Darwin': { 'user': 'administrator' }
+    },
+    base='defaults',
+    merge=salt.pillar.get('homebrew', {}),
+    grain='kernel'
+  )
+%}

--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -1,3 +1,5 @@
+{% from 'map.jinja' import homebrew with context %}
+
 servo-dependencies:
   pkg.installed:
     - pkgs:
@@ -46,7 +48,7 @@ servo-darwin-homebrew-versions-dependencies:
 homebrew-link-autoconf:
   cmd.run:
     - name: 'brew link --overwrite autoconf'
-    - user: administrator
+    - user: {{ homebrew.user }}
     - creates: /usr/local/Library/LinkedKegs/autoconf
     - require:
       - pkg: servo-dependencies
@@ -55,7 +57,7 @@ homebrew-link-autoconf:
 homebrew-link-openssl:
   cmd.run:
     - name: 'brew link --force openssl'
-    - user: administrator
+    - user: {{ homebrew.user }}
     - creates: /usr/local/Library/LinkedKegs/openssl
     - require:
       - pkg: servo-dependencies


### PR DESCRIPTION
This should be manually tested to a) make sure I didn't break the autoconf linkage, and b) to ensure the openssl linkage works properly.

Closes #210 (for real this time!)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/218)
<!-- Reviewable:end -->
