### PR TITLE
Add an operators group

### DIFF
--- a/homu/cfg.toml
+++ b/homu/cfg.toml
@@ -85,9 +85,12 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
     "zmike",
 ] %}
 
+{% set operators = [
+    "bholley",
+] %}
+
 {% set try = [
     "askalski",
-    "bholley",
     "chandler",
     "dzbarsky",
     "gsnedders",
@@ -100,7 +103,7 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
 [repo.servo]
 owner = "servo"
 name = "servo"
-reviewers = {{ reviewers }}
+reviewers = {{ reviewers + operators}}
 try_users = {{ try }}
 
 [repo.servo.github]
@@ -121,7 +124,7 @@ password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 [repo.{{ repo[1] }}]
 owner = "{{ repo[0] }}"
 name = "{{ repo[1] }}"
-reviewers = {{ reviewers }}
+reviewers = {{ reviewers + operators }}
 try_users = {{ try }}
 
 [repo.{{ repo[1] }}.github]


### PR DESCRIPTION
r?  @Manishearth 

Manish, do you have any idea how I can test this without dropping things on their head? The goal here is to have a "role" for operators, separate from that of reviewers (even if it's the same thing under the hood) to let people self-retry without waiting for delegate permissions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/220)
<!-- Reviewable:end -->
