### PR TITLE
Change node order to speed up Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,7 @@ language: cpp
 # sudo: required and dist: trusty enable usage of Trusty
 matrix:
   include:
-    - env: SALT_NODE_ID=servo-master
-      os: linux
-      sudo: required
-      dist: trusty
-    - env: SALT_NODE_ID=servo-mac1
-      os: osx
-    - env: SALT_NODE_ID=servo-macpro1
-      os: osx
-    - env: SALT_NODE_ID=servo-linux1
+    - env: SALT_NODE_ID=servo-head
       os: linux
       sudo: required
       dist: trusty
@@ -22,7 +14,13 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-    - env: SALT_NODE_ID=servo-head
+    - env: SALT_NODE_ID=servo-mac1
+      os: osx
+    - env: SALT_NODE_ID=servo-linux1
+      os: linux
+      sudo: required
+      dist: trusty
+    - env: SALT_NODE_ID=servo-master
       os: linux
       sudo: required
       dist: trusty

--- a/top.sls
+++ b/top.sls
@@ -5,10 +5,15 @@ base:
     - common
     - servo-dependencies
 
-  'servo-master':
-    - buildbot.master
-    - homu
-    - nginx
+  'servo-head':
+    - buildbot.slave
+    - android-dependencies
+
+  'servo-linux-android\d+':
+    - match: pcre
+    - buildbot.slave
+    - android-dependencies
+    - gonk-dependencies
 
   'servo-(mac|macpro)\d+':
     - match: pcre
@@ -19,12 +24,7 @@ base:
     - buildbot.slave
     - xvfb
 
-  'servo-linux-android\d+':
-    - match: pcre
-    - buildbot.slave
-    - android-dependencies
-    - gonk-dependencies
-
-  'servo-head':
-    - buildbot.slave
-    - android-dependencies
+  'servo-master':
+    - buildbot.master
+    - homu
+    - nginx


### PR DESCRIPTION
By putting the longest builds first, Travis should be able to use
the builders more efficiently. Also reordered top.sls to match
and removed servo-macpro1 from .travis.yml because it duplicates
servo-mac1.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/223)
<!-- Reviewable:end -->
