### PR TITLE
Use Salt to manage increased maxfiles on OS X

### DIFF
--- a/osx/files/profile
+++ b/osx/files/profile
@@ -1,0 +1,11 @@
+# System-wide .profile for sh(1)
+
+if [ -x /usr/libexec/path_helper ]; then
+        eval `/usr/libexec/path_helper -s`
+fi
+
+if [ "${BASH-no}" != "no" ]; then
+        [ -r /etc/bashrc ] && . /etc/bashrc
+fi
+
+ulimit -n 10240

--- a/osx/files/sysctl.conf
+++ b/osx/files/sysctl.conf
@@ -1,0 +1,3 @@
+kern.maxfiles=65536
+kern.maxfilesperproc=30000
+kern.ipc.somaxconn=2048

--- a/osx/init.sls
+++ b/osx/init.sls
@@ -1,0 +1,13 @@
+/etc/sysctl.conf:
+  file.managed:
+    - user: root
+    - group: wheel
+    - mode: 644
+    - source: salt://{{ tpldir }}/files/sysctl.conf
+
+/etc/profile:
+  file.managed:
+    - user: root
+    - group: wheel
+    - mode: 644
+    - source: salt://{{ tpldir }}/files/profile

--- a/top.sls
+++ b/top.sls
@@ -17,6 +17,7 @@ base:
 
   'servo-(mac|macpro)\d+':
     - match: pcre
+    - osx
     - buildbot.slave
 
   'servo-linux\d+':


### PR DESCRIPTION
These settings are necessary to handle running the WPT (web platform
tests); taken out of the wiki to reduce the need for manual
interventions.

Note, /etc/launchd.conf is not included because OS X no longer uses
this file and it has no effect. Whether a replacement for this
functionality is required is TBD.

Also, note that this hasn't been tested since there is no OS X Vagrant box.

cc @larsbergstrom since you added the maxfiles section to the wiki

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/227)
<!-- Reviewable:end -->
