### PR TITLE
Pin virtualenv pip package to pin installed binary

### DIFF
--- a/common/init.sls
+++ b/common/init.sls
@@ -22,11 +22,12 @@ pip:
       {% endif %}
     - reload_modules: True
 
-# Virtualenv package creates virtualenv and virtualenv-3.4 executables
+# virtualenv == 14.0.6 package creates virtualenv and virtualenv-3.5 executables
+# note that the version of the second may change between virtualenv versions
 virtualenv:
   pip.installed:
     - pkgs:
-      - virtualenv
+      - virtualenv == 14.0.6
     - require:
       - pkg: pip
 

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -11,7 +11,7 @@ homu:
     - user: servo
   virtualenv.managed:
     - name: /home/servo/homu/_venv
-    - venv_bin: virtualenv-3.4
+    - venv_bin: virtualenv-3.5
     - python: python3
     - system_site_packages: False
     - require:


### PR DESCRIPTION
I noticed homu broke (sometime today I guess) while working on another PR.

A recent update of the virtualenv package changed the installed
binaries from `virtualenv` and `virtualenv-3.4`, to `virtualenv` and
`virtualenv-3.5`, breaking the homu installation which needs a python3
version of virtualenv. Pin the package to the newest version and update
the homu installation to use the virtualenv-3.5 binary.

Note: the python3 apt package still installs python3.4, but the version
difference should be ok since virtualenv is just used to install homu,
not run it.

@Manishearth as I said in the commit message I don't think combining
python3.4 and virtualenv-3.5 should cause problems, but how can I test
homu manually to make sure it runs properly?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/228)
<!-- Reviewable:end -->
