### PR TITLE
Add appveyor support for servo's homu

### DIFF
--- a/homu/cfg.toml
+++ b/homu/cfg.toml
@@ -120,6 +120,9 @@ try_builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wp
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 
+[repo.servo.status.appveyor]
+context = 'continuous-integration/appveyor/branch'
+
 # Standard per-repo configs (generated)
 
 {% for repo in travis_repos %}

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -6,7 +6,7 @@ python3:
 homu:
   git.latest:
     - name: https://github.com/servo/homu
-    - rev: e07f74e7a3a185768e71639d6a328ef8ea234f92
+    - rev: 6ef9a768041883a9d6c779bc0ec2174aee3eb8e2
     - target: /home/servo/homu
     - user: servo
   virtualenv.managed:


### PR DESCRIPTION
Don't merge yet, needs https://github.com/servo/homu/pull/13 to merge and then a bump in the homu SHA
r? @larsbergstrom

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/232)
<!-- Reviewable:end -->
