### PR TITLE
Test commit to check Travis's apt sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ matrix:
 script:
   - cat /etc/apt/sources.list
   - ls -al /etc/apt/sources.list.d
-  - for f in /etc/apt/sources.list.d; do cat $f; done
+  - for f in /etc/apt/sources.list.d/*; do cat $f; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,20 +25,7 @@ matrix:
       sudo: required
       dist: trusty
 
-before_install:
-  - .travis/install_salt -F -c .travis -- "${TRAVIS_OS_NAME}"
-
-install:
-  - .travis/setup_salt_roots
-
-  # For debugging, check the grains reported by the Travis builder
-  - sudo salt-call --id="${SALT_NODE_ID}" grains.items
-
 script:
-  # Minimally validate YAML and Jinja at a basic level
-  - sudo salt-call --id="${SALT_NODE_ID}" --retcode-passthrough state.show_highstate
-  # Full on installation test
-  - sudo salt-call --id="${SALT_NODE_ID}" --retcode-passthrough state.highstate
-
-notifications:
-  webhooks: http://build.servo.org:54856/travis
+  - cat /etc/apt/sources.list
+  - ls -al /etc/apt/sources.list.d
+  - for f in /etc/apt/sources.list.d; do cat $f; done


### PR DESCRIPTION
Google has just dropped support for 32-bit Chrome, and it seems that
Travis has the Chrome repository enabled, causing build failures on our
multi-arch machines. This is a commit to check if Travis actually does
have Chrome in its sources.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/233)
<!-- Reviewable:end -->
