### PR TITLE
Remove non-Salted external apt sources

### DIFF
--- a/longview/init.sls
+++ b/longview/init.sls
@@ -1,0 +1,8 @@
+longview:
+  pkgrepo.managed:
+    - name: 'deb http://apt-longview.linode.com/ trusty main'
+    - file: /etc/apt/sources.list.d/longview.list
+    - key_url: https://apt-longview.linode.com/linode.gpg
+    - require:
+      - file: /etc/apt/sources.list.d
+

--- a/top.sls
+++ b/top.sls
@@ -33,3 +33,4 @@ base:
     - buildbot.master
     - homu
     - nginx
+    - longview

--- a/ubuntu/init.sls
+++ b/ubuntu/init.sls
@@ -6,3 +6,18 @@
     - group: root
     - mode: 755
     - source: salt://{{ tpldir }}/files/policy-rc.d
+
+# Workaround for https://github.com/saltstack/salt/issues/26605
+# Clean the directory first, and require it in all pkgrepo states
+# which add repositories to the sources.list.d folder (instead of
+# the main /etc/apt/sources.list file)
+/etc/apt/sources.list.d:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - recurse:
+      - user
+      - group
+      - mode
+    - clean: True


### PR DESCRIPTION
Workaround https://github.com/saltstack/salt/issues/26605
by cleaning the sources.list.d folder first, and running
pkgrepo states that add repositories to the folder afterwards
using require.

This unbreaks #232: Travis has the Chrome apt repo configured, but
Google has dropped 32-bit support (March 2016), causing apt to fail
on multiarch hosts. By removing all external repos we will only use
repositories we configure ourselves.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/234)
<!-- Reviewable:end -->
