### PR TITLE
Revert "Don't run Travis builds on master"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@
 # But a system python is installed for all workers
 language: cpp
 
-branches:
-  except:
-    - master
-
 # NOTE: Make sure the matrix covers all node types in top.sls
 # sudo: required and dist: trusty enable usage of Trusty
 matrix:


### PR DESCRIPTION
This reverts commit 9cbbbf0b1008a0566667125bf069c2e3c916f4f8.

See https://github.com/servo/saltfs/pull/235#issuecomment-192800632 for the reasoning on the revert.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/236)
<!-- Reviewable:end -->
