### PR TITLE
Add support for ARM32/ARM64 to our build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-    - env: SALT_NODE_ID=servo-linux-android1
+    - env: SALT_NODE_ID=servo-linux-cross1
       os: linux
       sudo: required
       dist: trusty

--- a/.travis/test_pillars/top.sls
+++ b/.travis/test_pillars/top.sls
@@ -15,7 +15,7 @@ base:
     - match: pcre
     - buildbot.slave
 
-  'servo-linux-android\d+':
+  'servo-linux-cross\d+':
     - match: pcre
     - buildbot.slave
 

--- a/arm-dependencies.sls
+++ b/arm-dependencies.sls
@@ -1,0 +1,111 @@
+{% from 'common/map.jinja' import config %}
+
+arm-dependencies:
+  pkg.installed:
+    - pkgs:
+      - g++-aarch64-linux-gnu
+      - g++-arm-linux-gnueabihf
+
+{% set rootfs_repo = 'https://servo-rust.s3.amazonaws.com/ARM' %}
+{% set targets = [{
+                    'name': 'arm-linux-gnueabihf',
+                    'symlink_name': 'arm-unknown-linux-gnueabihf',
+                    'version': 'v1',
+                    'local_name': 'armhf-trusty-libs.tgz',
+                    'hash': 'd9a31ed488e4f848efcd07f71aa167fc73252da2a2c3b53ba8216100e2b4302b5ccd273b27c434ad189650652a1877607d328ff6b8e1edb5aa68a8927c617b49',
+                  },
+                  {
+                    'name': 'aarch64-linux-gnu',
+                    'symlink_name': 'aarch64-unknown-linux-gnu',
+                    'version': 'v1',
+                    'local_name': 'arm64-trusty-libs.tgz',
+                    'hash': '6c86097188b70940835b2fc936fe70f01890fae45ba4ef79dcccc6a552ad319dcba23e21d6c849fd9d396e0c2f4476a21c93f9b3d4abb4f34d69f22d18017b1b',
+                  }] %}
+
+{% set binaries = [
+    'elfedit',
+    'gcov',
+    'nm',
+    'addr2line',
+    'g++',
+    'objcopy',
+    'ar',
+    'objdump',
+    'as',
+    'gcc',
+    'ranlib',
+    'c++filt',
+    'gprof',
+    'readelf',
+    'cpp',
+    'ld',
+    'size',
+    'ld.bfd',
+    'strings',
+    'strip'
+] %}
+
+{% for target in targets %}
+
+libs-{{ target.name }}:
+  archive.extracted:
+    - name: {{ config.servo_home }}/rootfs-trusty-{{ target.name }}/{{ target.version }} # Directory to extract into
+    - source: {{ rootfs_repo }}/{{ target.version }}/{{ target.local_name }}
+    - source_hash: sha512={{ target.hash }}
+    - archive_format: tar
+    - archive_user: servo # 2015.8 moves these to the standard user and group parameters
+
+{% for binary in binaries %}
+{{ config.servo_home }}/bin/{{ target.symlink_name }}-{{ binary }}:
+  file.symlink:
+    - target: /usr/bin/{{ target.name }}-{{ binary }}
+    - makedirs: True
+    - require:
+      - archive: libs-{{ target.name }}
+{% endfor %}
+
+{{ config.servo_home }}/rootfs-trusty-{{ target.name }}/{{ target.version }}:
+  file.directory:
+    - user: servo
+    - group: servo
+    - dir_mode: 755
+    - file_mode: 644
+    - makedirs: True
+    - require:
+      - archive: libs-{{ target.name }}
+
+{{ config.servo_home }}/rootfs-trusty-{{ target.name }}:
+  file.directory:
+    - user: servo
+    - group: servo
+    - dir_mode: 755
+    - file_mode: 644
+    - makedirs: True
+    - clean: True
+    - require:
+      - file: {{ config.servo_home }}/rootfs-trusty-{{ target.name }}/{{ target.version }}
+
+{% for root in ['usr/include', 'usr/lib', 'lib'] %}
+/{{ root }}/{{ target.name }}:
+  file.symlink:
+    - target: {{ config.servo_home }}/rootfs-trusty-{{ target.name }}/{{ target.version }}/{{ root }}/{{ target.name }}
+    - require:
+      - archive: libs-{{ target.name }}
+{% endfor %}
+
+{% endfor %}
+
+{{ config.servo_home }}/bin:
+  file.directory:
+    - user: servo
+    - group: servo
+    - dir_mode: 755
+    - file_mode: 644
+    - makedirs: True
+    - clean: True
+    - require:
+      {% for target in targets %}
+      {% for binary in binaries %}
+      - file: {{ config.servo_home }}/bin/{{ target.symlink_name }}-{{ binary }}
+      {% endfor %}
+      {% endfor %}

--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -11,7 +11,7 @@ SERVO_REPO = "https://github.com/servo/servo"
 HEAD_SLAVES = ["servo-head"]
 LINUX_RESERVED_SLAVES = ["servo-linux1", "servo-linux2"]
 MAC_SLAVES = ["servo-mac1", "servo-mac2", "servo-mac3"]
-ANDROID_SLAVES = ["servo-linux-android1"]
+CROSS_SLAVES = ["servo-linux-cross1"]
 
 # These will lock a project to a single platform
 MAC_ONLY_PROJECTS = ['servo/io-surface-rs']
@@ -30,7 +30,7 @@ c['caches'] = {
 ####### BUILDSLAVES
 
 c['slaves'] = []
-for s in MAC_SLAVES + ANDROID_SLAVES + HEAD_SLAVES + LINUX_RESERVED_SLAVES:
+for s in MAC_SLAVES + CROSS_SLAVES + HEAD_SLAVES + LINUX_RESERVED_SLAVES:
     c['slaves'].append(buildslave.BuildSlave(s, SLAVE_PASSWORD, max_builds=1))
 
 ####### CHANGESOURCES
@@ -72,7 +72,7 @@ c['schedulers'] = []
 c['schedulers'].append(schedulers.AnyBranchScheduler(
     name="servo-auto",
     treeStableTimer=None,
-    builderNames=["linux-dev", "linux-rel", "mac-rel-wpt", "mac-dev-unit", "mac-rel-css", "android", "gonk"],
+    builderNames=["linux-dev", "linux-rel", "mac-rel-wpt", "mac-dev-unit", "mac-rel-css", "android", "gonk", "arm32", "arm64"],
     change_filter=util.ChangeFilter(filter_fn=servo_auto_try_filter),
 ))
 c['schedulers'].append(schedulers.SingleBranchScheduler(
@@ -83,7 +83,7 @@ c['schedulers'].append(schedulers.SingleBranchScheduler(
 ))
 c['schedulers'].append(schedulers.ForceScheduler(
     name="force",
-    builderNames=["linux-dev", "linux-rel", "mac-rel-wpt", "mac-dev-unit", "mac-rel-css", "android", "gonk", "android-nightly"]
+    builderNames=["linux-dev", "linux-rel", "mac-rel-wpt", "mac-dev-unit", "mac-rel-css", "android", "gonk", "arm32", "arm64", "android-nightly"]
 ))
 c['schedulers'].append(schedulers.Nightly(
     name="Nightly",
@@ -242,6 +242,34 @@ gonk_factory = create_servo_factory([
     steps.ShellCommand(command=["bash", "./etc/ci/manifest_changed.sh"], env=gonk_compile_env),
 ])
 
+arm32_compile_env = dict({'PATH': '/home/servo/bin:$PATH',
+                          'BUILD_TARGET': 'arm-unknown-linux-gnueabihf',
+                          'PKG_CONFIG_ALLOW_CROSS': '1',
+                          'PKG_CONFIG_PATH': '/usr/lib/arm-linux-gnueabihf/pkgconfig',
+                          'EXPAT_NO_PKG_CONFIG': '1',
+                          'FREETYPE2_NO_PKG_CONFIG': '1',
+                          'FONTCONFIG_NO_PKG_CONFIG': '1'
+                          'CC': 'arm-linux-gnueabihf-gcc',
+                          'CXX': 'arm-linux-gnueabihf-g++'},
+                        **linux_test_env)
+arm32_factory = create_servo_factory([
+    steps.Compile(command=["./mach", "build", "--rel", "--target=$BUILD_TARGET"], env=arm32_compile_env),
+])
+
+arm64_compile_env = dict({'PATH': '/home/servo/bin:$PATH',
+                          'BUILD_TARGET': 'aarch64-unknown-linux-gnu',
+                          'PKG_CONFIG_ALLOW_CROSS': '1',
+                          'PKG_CONFIG_PATH': '/usr/lib/aarch64-linux-gnu/pkgconfig',
+                          'EXPAT_NO_PKG_CONFIG': '1',
+                          'FREETYPE2_NO_PKG_CONFIG': '1',
+                          'FONTCONFIG_NO_PKG_CONFIG': '1'
+                          'CC': 'aarch64-linux-gnu-gcc',
+                          'CXX': 'aarch64-linux-gnu-g++'},
+                        **linux_test_env)
+arm64_factory = create_servo_factory([
+    steps.Compile(command=["./mach", "build", "--rel", "--target=$BUILD_TARGET"], env=arm64_compile_env),
+])
+
 doc_factory = create_servo_factory([
     steps.ShellCommand(command=["etc/ci/upload_docs.sh"],
                        env={'TOKEN': GITHUB_DOC_TOKEN,
@@ -308,16 +336,29 @@ c['builders'].append(util.BuilderConfig(
 ))
 c['builders'].append(util.BuilderConfig(
     name="android",
-    slavenames=ANDROID_SLAVES,
+    slavenames=CROSS_SLAVES,
     factory=android_factory,
     nextBuild=branch_priority,
     category="auto",
 ))
-# NOTE: gonk currently shares the android builder.
 c['builders'].append(util.BuilderConfig(
     name="gonk",
-    slavenames=ANDROID_SLAVES,
+    slavenames=CROSS_SLAVES,
     factory=gonk_factory,
+    nextBuild=branch_priority,
+    category="auto",
+))
+c['builders'].append(util.BuilderConfig(
+    name="arm32",
+    slavenames=CROSS_SLAVES,
+    factory=arm32_factory,
+    nextBuild=branch_priority,
+    category="auto",
+))
+c['builders'].append(util.BuilderConfig(
+    name="arm64",
+    slavenames=CROSS_SLAVES,
+    factory=arm64_factory,
     nextBuild=branch_priority,
     category="auto",
 ))

--- a/top.sls
+++ b/top.sls
@@ -13,11 +13,12 @@ base:
     - buildbot.slave
     - android-dependencies
 
-  'servo-linux-android\d+':
+  'servo-linux-cross\d+':
     - match: pcre
     - buildbot.slave
     - android-dependencies
     - gonk-dependencies
+    - arm-dependencies
 
   'servo-(mac|macpro)\d+':
     - match: pcre


### PR DESCRIPTION
r? @aneeshusa 

I tested these changes inside of the *awesome* vagrant setup, and they seem to work locally, so I think that the next step is to review my miserable salt work.

There's some pretty hack-y stuff - assumptions of target triples differ between the Rust compiler, installed gcc binaries, and configure scripts, so there is some `PATH` and symlink hackery going on that could hopefully be reduced over time.

I've also renamed `servo-linux-androidN` to `servo-linux-crossN`, to better reflect the change. I'm assuming that we will need two cross builders online for {android, gonk, arm32, arm64} builds. Possibly three, as arm32/arm64 release builds are *slow*.

CC @edunham @Manishearth @metajack @mmatyas

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/239)
<!-- Reviewable:end -->
