### PR TITLE
Ensure Vagrant version is at least 1.8.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ def extract_id(env)
   id[0]
 end
 
+Vagrant.require_version '>= 1.8.0'
+
 Vagrant.configure(2) do |config|
 
   if Vagrant.has_plugin?('vagrant-cachier')
@@ -39,9 +41,7 @@ Vagrant.configure(2) do |config|
       machine.vm.provider :virtualbox do |vbox|
         # Need extra memory for downloading large files (e.g. Android SDK)
         vbox.memory = 1024
-        if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
-          vbox.linked_clone = true
-        end
+        vbox.linked_clone = true
       end
       machine.vm.synced_folder dir, state_root
       machine.vm.synced_folder File.join(dir, ".travis/test_pillars"), pillar_root


### PR DESCRIPTION
Use the Vagrant.require_version helper documented here:
https://www.vagrantup.com/docs/vagrantfile/vagrant_version.html

Eliminates issues like #238.

Heads up: I didn't test this with a Vagrant older than 1.8.0, so I have no idea if this actually works.
@larsbergstrom can you test this if possible since you ran into this?
I want to make sure this is actually a useful change.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/240)
<!-- Reviewable:end -->
