### PR TITLE
Use Vagrant to set the VM hostname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ def extract_id(env)
   id[0]
 end
 
-Vagrant.require_version '>= 1.8.0'
+Vagrant.require_version '>= 1.8.5'
 
 Vagrant.configure(2) do |config|
 
@@ -48,13 +48,12 @@ Vagrant.configure(2) do |config|
       end
       machine.vm.synced_folder dir, state_root
       machine.vm.synced_folder File.join(dir, '.travis', 'test_pillars'), pillar_root
+      machine.vm.hostname = node[:id]
       machine.vm.provision :salt do |salt|
         salt.bootstrap_script = File.join(dir, '.travis', 'install_salt.sh')
         salt.install_args = node[:os] # Pass OS type to bootstrap script
         salt.masterless = true
         salt.minion_config = minion_config_path
-        # hack to provide additional options to salt-call
-        salt.minion_id = node[:id] + ' --retcode-passthrough'
         salt.run_highstate = true
         salt.verbose = true
         salt.log_level = 'info'


### PR DESCRIPTION
This has the benefit that Salt will automatically pick up on the
hostname and use it as the minion id, removing the need to manually
pass the minion ID in the Vagrantfile and when debugging inside the VM.

This is blocked on https://github.com/mitchellh/vagrant/pull/7137 landing
and getting released in a new Vagrant version.

Reminder to self: update the wiki when this lands.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/248)

<!-- Reviewable:end -->
