### PR TITLE
Call a new script to check dynamic symbols in Android binary #8351

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -219,6 +219,7 @@ android_factory = create_servo_factory([
     steps.Compile(command=["./mach", "build", "--android", "--dev"], env=android_compile_env),
     steps.ShellCommand(command=["bash", "./etc/ci/lockfile_changed.sh"], env=android_compile_env),
     steps.ShellCommand(command=["bash", "./etc/ci/manifest_changed.sh"], env=android_compile_env),
+    steps.ShellCommand(command=["python", "./etc/ci/check_dynamic_symbols.py"], env=android_compile_env),
 ])
 
 android_nightly_factory = create_servo_factory([


### PR DESCRIPTION
Tries to fix #8351.

This is meaningful only with the PR to servo/servo

Cross PR: https://github.com/servo/servo/pull/9981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/249)
<!-- Reviewable:end -->
