### PR TITLE
Standardize pkgrepo usage

### DIFF
--- a/.travis/install_salt
+++ b/.travis/install_salt
@@ -11,7 +11,7 @@ install_salt () {
         # Don't autostart services
         printf '#!/bin/sh\nexit 101\n' | sudo install -m 755 /dev/stdin /usr/sbin/policy-rc.d
         curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8 trusty main\n' | sudo tee -a /etc/apt/sources.list >/dev/null
+        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8 trusty main\n' | sudo tee /etc/apt/sources.list.d/saltstack.list >/dev/null
         sudo apt-get -y update
         sudo apt-get -y install salt-minion=2015.5.8+ds-1
     elif [ "${OS_NAME}" = "osx" ]; then

--- a/longview/init.sls
+++ b/longview/init.sls
@@ -3,6 +3,10 @@ longview:
     - name: 'deb http://apt-longview.linode.com/ trusty main'
     - file: /etc/apt/sources.list.d/longview.list
     - key_url: https://apt-longview.linode.com/linode.gpg
-    - require:
-      - file: /etc/apt/sources.list.d
 
+/etc/apt/sources.list.d/longview.list:
+  file.exists:
+    - require:
+      - pkgrepo: longview
+    - require_in:
+      - file: /etc/apt/sources.list.d

--- a/salt/common.sls
+++ b/salt/common.sls
@@ -1,0 +1,16 @@
+{% from tpldir ~ '/map.jinja' import salt %}
+
+{% if grains['os'] == 'Ubuntu' %}
+salt:
+  pkgrepo.managed:
+    - name: 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }} trusty main'
+    - file: /etc/apt/sources.list.d/saltstack.list
+    - key_url: https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }}/SALTSTACK_GPG_KEY.pub
+
+/etc/apt/sources.list.d/saltstack.list:
+  file.exists:
+    - require:
+      - pkgrepo: salt
+    - require_in:
+      - file: /etc/apt/sources.list.d
+{% endif %}

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -1,0 +1,10 @@
+{%
+  set salt = salt.grains.filter_by({
+      'defaults': {
+        'version':  '2015.5.8'
+      },
+    },
+    base='defaults',
+    merge=salt.pillar.get('salt', {})
+  )
+%}

--- a/servo-dependencies.sls
+++ b/servo-dependencies.sls
@@ -64,21 +64,26 @@ homebrew-link-openssl:
     - require:
       - pkg: servo-dependencies
 {% else %}
-FIX enable multiverse:
-  pkgrepo.absent:
-    - name: deb http://archive.ubuntu.com/ubuntu trusty multiverse
-
-enable multiverse:
+multiverse:
   pkgrepo.managed:
-    - name: deb http://archive.ubuntu.com/ubuntu trusty multiverse
+    - name: 'deb http://archive.ubuntu.com/ubuntu trusty multiverse'
+    - file: /etc/apt/sources.list.d/multiverse.list
+    - require_in:
+      - pkg: ttf-mscorefonts-installer
+
+/etc/apt/sources.list.d/multiverse.list:
+  file.exists:
+    - require:
+      - pkgrepo: multiverse
+    - require_in:
+      - file: /etc/apt/sources.list.d
 
 ttf-mscorefonts-installer:
   debconf.set:
-    - name: ttf-mscorefonts-installer
     - data: { 'msttcorefonts/accepted-mscorefonts-eula': { 'type': 'boolean', 'value': True } }
   pkg.installed:
     - pkgs:
       - ttf-mscorefonts-installer
-    - requires:
+    - require:
       - debconf: ttf-mscorefonts-installer
 {% endif %}

--- a/top.sls
+++ b/top.sls
@@ -4,6 +4,7 @@ base:
   '*':
     - common
     - servo-dependencies
+    - salt.common
 
   'os:Ubuntu':
     - match: grain

--- a/ubuntu/init.sls
+++ b/ubuntu/init.sls
@@ -7,14 +7,16 @@
     - mode: 755
     - source: salt://{{ tpldir }}/files/policy-rc.d
 
-# Workaround for https://github.com/saltstack/salt/issues/26605
-# Clean the directory first, and require it in all pkgrepo states
-# which add repositories to the sources.list.d folder (instead of
-# the main /etc/apt/sources.list file)
+# Workaround for https://github.com/saltstack/salt/issues/26605:
+# For each pkgrepo state which adds any repositories to the sources.list.d
+# folder (instead of the main /etc/apt/sources.list file), create an extra,
+# no-op file.exists state which requires the pkgrepo state and require_ins
+# this state
 /etc/apt/sources.list.d:
   file.directory:
     - user: root
     - group: root
+    - file_mode: 644
     - dir_mode: 755
     - recurse:
       - user


### PR DESCRIPTION
This changes our workaround to be more verbose with no-op states but
more robust in the case of pkrepo failures: the directory will not be
cleaned until after all of the pkgrepo states complete succesfully.

This also cleans up the MS TTF core fonts, and should help with #186.
Note that it appears the Vagrant `ubuntu/trusty64` image that we use
already has the `multiverse` repository enabled, which might be why
I can't reproduce #186 inside Vagrant; it may be worth spinning up a
temporary EC2 instance to test this out (probably in masterless/local
mode instead of having it connect to `servo-master`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/250)
<!-- Reviewable:end -->
