### PR TITLE
Create user accounts instead of sharing root

### DIFF
--- a/common/init.sls
+++ b/common/init.sls
@@ -47,7 +47,7 @@ host-{{ hostname }}:
 {% for ssh_user in common.ssh_users %}
 {{ ssh_user }}:
   user.present:
-    - home: /home/{{ ssh_user }}
+    - createhome: True
     - optional_groups:
         - wheel
     - empty_password: True

--- a/common/init.sls
+++ b/common/init.sls
@@ -45,8 +45,15 @@ host-{{ hostname }}:
 {% endfor %}
 
 {% for ssh_user in common.ssh_users %}
+{{ ssh_user }}:
+  user.present:
+    - home: /home/{{ ssh_user }}
+    - optional_groups:
+        - wheel
+    - empty_password: True
+
 sshkey-{{ ssh_user }}:
   ssh_auth.present:
-    - user: root
+    - user: {{ ssh_user }}
     - source: salt://{{ tpldir }}/ssh/{{ ssh_user }}.pub
 {% endfor %}


### PR DESCRIPTION
SSH best practices is to fully disallow remote root login. To do that, we have to start by getting everyone logging in as themselves. 

r? @aneeshusa

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/253)

<!-- Reviewable:end -->
