### PR TITLE
expand path manually

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -242,7 +242,7 @@ gonk_factory = create_servo_factory([
     steps.ShellCommand(command=["bash", "./etc/ci/manifest_changed.sh"], env=gonk_compile_env),
 ])
 
-arm32_compile_env = dict({'PATH': '/home/servo/bin:$PATH',
+arm32_compile_env = dict({'PATH': '/home/servo/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin',
                           'BUILD_TARGET': 'arm-unknown-linux-gnueabihf',
                           'PKG_CONFIG_ALLOW_CROSS': '1',
                           'PKG_CONFIG_PATH': '/usr/lib/arm-linux-gnueabihf/pkgconfig',
@@ -256,7 +256,7 @@ arm32_factory = create_servo_factory([
     steps.Compile(command=["./mach", "build", "--rel", "--target=$BUILD_TARGET"], env=arm32_compile_env),
 ])
 
-arm64_compile_env = dict({'PATH': '/home/servo/bin:$PATH',
+arm64_compile_env = dict({'PATH': '/home/servo/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin',
                           'BUILD_TARGET': 'aarch64-unknown-linux-gnu',
                           'PKG_CONFIG_ALLOW_CROSS': '1',
                           'PKG_CONFIG_PATH': '/usr/lib/aarch64-linux-gnu/pkgconfig',


### PR DESCRIPTION
r? @edunham 

Path is not actually expanded (see http://build.servo.org/builders/arm64/builds/3/steps/compile/logs/stdio), so we were getting `PATH=/home/servo/bin:$PATH`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/258)
<!-- Reviewable:end -->
