### PR TITLE
NDK installation should run whenever it's not installed

### DIFF
--- a/android-dependencies.sls
+++ b/android-dependencies.sls
@@ -72,13 +72,12 @@ android-ndk:
       - file: android-ndk
 
 android-ndk-toolset-configuration:
-  cmd.wait:
+  cmd.run:
     - name: bash /home/servo/android-ndk-r10e/build/tools/make-standalone-toolchain.sh --platform=android-18 --toolchain=arm-linux-androideabi-4.8 --install-dir='/home/servo/ndk-toolchain' --ndk-dir='/home/servo/android-ndk-r10e'
     - user: servo
     - require:
       - cmd: android-sdk
-    - watch:
-      - cmd: android-ndk
+    - creates: /home/servo/ndk-toolchain
 
 /home/servo/.bash_profile:
   file.managed:


### PR DESCRIPTION
According to
https://docs.saltstack.com/en/latest/ref/states/all/salt.states.cmd.html#should-i-use-cmd-run-or-cmd-wait,
ndk installation will only try to run if the ndk was just downloaded.

In the old implementation, if you succeed at downloading the ndk but fail to
install it, subsequent highstates won't attempt to install the ndk because the
downloaded file will be unchanged.

With these changes, we decide whether to install the ndk based on whether the directory created by installation exists, rather than based on whether we downloaded the file this run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/259)
<!-- Reviewable:end -->
