### PR TITLE
fix typo in GPG key URL

### DIFF
--- a/salt/common.sls
+++ b/salt/common.sls
@@ -5,7 +5,7 @@ salt:
   pkgrepo.managed:
     - name: 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }} trusty main'
     - file: /etc/apt/sources.list.d/saltstack.list
-    - key_url: https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }}/SALTSTACK_GPG_KEY.pub
+    - key_url: https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }}/SALTSTACK-GPG-KEY.pub
 
 /etc/apt/sources.list.d/saltstack.list:
   file.exists:


### PR DESCRIPTION
```
          ID: salt
    Function: pkgrepo.managed
        Name: deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8 trusty main
      Result: False
     Comment: Failed to configure repo 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8 trusty main': HTTP error 404 reading https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.5.8/SALTSTACK_GPG_KEY.pub: Nothing matches the given URI
     Started: 21:28:51.364059
    Duration: 472.773 ms
     Changes: 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/266)
<!-- Reviewable:end -->
