### PR TITLE
Update ARM rootfs urls to nest version inside name

### DIFF
--- a/servo-build-dependencies/arm.sls
+++ b/servo-build-dependencies/arm.sls
@@ -1,4 +1,5 @@
 {% from 'common/map.jinja' import common %}
+{% from tpldir ~ '/map.jinja' import arm %}
 
 arm-dependencies:
   pkg.installed:
@@ -6,21 +7,6 @@ arm-dependencies:
       - g++-aarch64-linux-gnu
       - g++-arm-linux-gnueabihf
 
-{% set rootfs_repo = 'https://servo-rust.s3.amazonaws.com/ARM' %}
-{% set targets = [{
-                    'name': 'arm-linux-gnueabihf',
-                    'symlink_name': 'arm-unknown-linux-gnueabihf',
-                    'version': 'v1',
-                    'local_name': 'armhf-trusty-libs.tgz',
-                    'hash': 'd9a31ed488e4f848efcd07f71aa167fc73252da2a2c3b53ba8216100e2b4302b5ccd273b27c434ad189650652a1877607d328ff6b8e1edb5aa68a8927c617b49',
-                  },
-                  {
-                    'name': 'aarch64-linux-gnu',
-                    'symlink_name': 'aarch64-unknown-linux-gnu',
-                    'version': 'v1',
-                    'local_name': 'arm64-trusty-libs.tgz',
-                    'hash': '6c86097188b70940835b2fc936fe70f01890fae45ba4ef79dcccc6a552ad319dcba23e21d6c849fd9d396e0c2f4476a21c93f9b3d4abb4f34d69f22d18017b1b',
-                  }] %}
 
 {% set binaries = [
     'elfedit',
@@ -45,15 +31,15 @@ arm-dependencies:
     'strip'
 ] %}
 
-{% for target in targets %}
+{% for target in arm.targets %}
 
 libs-{{ target.name }}:
   archive.extracted:
-    - name: {{ common.servo_home }}/rootfs-trusty-{{ target.name }}/{{ target.version }} # Directory to extract into
-    - source: {{ rootfs_repo }}/{{ target.version }}/{{ target.local_name }}
-    - source_hash: sha512={{ target.hash }}
+    - name: {{ common.servo_home }}/rootfs-trusty-{{ target.name }}/{{ target.version }}
+    - source: https://servo-rust.s3.amazonaws.com/ARM/{{ target.download_name }}/{{ target.version }}/{{ target.download_name }}-{{ target.version }}.tgz
+    - source_hash: sha512={{ target.sha512 }}
     - archive_format: tar
-    - archive_user: servo # 2015.8 moves these to the standard user and group parameters
+    - archive_user: servo
 
 {% for binary in binaries %}
 {{ common.servo_home }}/bin/{{ target.symlink_name }}-{{ binary }}:
@@ -104,7 +90,7 @@ libs-{{ target.name }}:
     - makedirs: True
     - clean: True
     - require:
-      {% for target in targets %}
+      {% for target in arm.targets %}
       {% for binary in binaries %}
       - file: {{ common.servo_home }}/bin/{{ target.symlink_name }}-{{ binary }}
       {% endfor %}

--- a/servo-build-dependencies/map.jinja
+++ b/servo-build-dependencies/map.jinja
@@ -12,6 +12,27 @@
 %}
 
 {%
+  set arm = {
+    'targets': [
+      {
+        'name': 'arm-linux-gnueabihf',
+        'download_name': 'armhf-trusty-libs.tgz',
+        'symlink_name': 'arm-unknown-linux-gnueabihf',
+        'version': 'v1',
+        'sha512': 'd9a31ed488e4f848efcd07f71aa167fc73252da2a2c3b53ba8216100e2b4302b5ccd273b27c434ad189650652a1877607d328ff6b8e1edb5aa68a8927c617b49'
+      },
+      {
+        'name': 'aarch64-linux-gnu',
+        'download_name': 'arm64-trusty-libs.tgz',
+        'symlink_name': 'aarch64-unknown-linux-gnu',
+        'version': 'v1',
+        'sha512': '6c86097188b70940835b2fc936fe70f01890fae45ba4ef79dcccc6a552ad319dcba23e21d6c849fd9d396e0c2f4476a21c93f9b3d4abb4f34d69f22d18017b1b'
+      }
+    ]
+  }
+%}
+
+{%
   set b2g = {
     'sha512': '092a3c9210ce4eae864dc07a4a17f5fc38aebdd0179d64d7b77a65bad2adc004a9599ef7bf1e6ce610abaecae87cd61af5d58ea5ac609028b429e514dfe96e77'
   }


### PR DESCRIPTION
This allows updating each of the rootfs tarballs separately.

Note that the exact format of the URLs is open to some bikeshedding, but I recommend this for the following reasons:
  - Switching the version and the name (so that version is inside name) lets you update the tarballs separately
  - Keeping the version in the actual file name lets you download different versions without them clobbering each other on disk

cc @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/268)
<!-- Reviewable:end -->
