### PR TITLE
Move everything off of the head/doc builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ language: cpp
 # sudo: required and dist: trusty enable usage of Trusty
 matrix:
   include:
-    - env: SALT_NODE_ID=servo-head
-      os: linux
-      sudo: required
-      dist: trusty
     - env: SALT_NODE_ID=servo-linux-cross1
       os: linux
       sudo: required

--- a/.travis/test_pillars/top.sls
+++ b/.travis/test_pillars/top.sls
@@ -18,6 +18,3 @@ base:
   'servo-linux-cross\d+':
     - match: pcre
     - buildbot.slave
-
-  'servo-head':
-    - buildbot.slave

--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -8,7 +8,6 @@ from passwords import HTTP_USERNAME, HTTP_PASSWORD, SLAVE_PASSWORD, CHANGE_PASSW
 from passwords import GITHUB_DOC_TOKEN, GITHUB_STATUS_TOKEN, HOMU_BUILDBOT_SECRET
 
 SERVO_REPO = "https://github.com/servo/servo"
-HEAD_SLAVES = ["servo-head"]
 LINUX_RESERVED_SLAVES = ["servo-linux1", "servo-linux2"]
 MAC_SLAVES = ["servo-mac1", "servo-mac2", "servo-mac3"]
 CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
@@ -30,7 +29,7 @@ c['caches'] = {
 ####### BUILDSLAVES
 
 c['slaves'] = []
-for s in MAC_SLAVES + CROSS_SLAVES + HEAD_SLAVES + LINUX_RESERVED_SLAVES:
+for s in MAC_SLAVES + CROSS_SLAVES + LINUX_RESERVED_SLAVES:
     c['slaves'].append(buildslave.BuildSlave(s, SLAVE_PASSWORD, max_builds=1))
 
 ####### CHANGESOURCES
@@ -387,13 +386,13 @@ c['builders'].append(util.BuilderConfig(
 ))
 c['builders'].append(util.BuilderConfig(
     name="doc",
-    slavenames=HEAD_SLAVES,
+    slavenames=LINUX_RESERVED_SLAVES,
     factory=doc_factory,
     category="auto",
 ))
 c['builders'].append(util.BuilderConfig(
     name="android-nightly",
-    slavenames=HEAD_SLAVES,
+    slavenames=CROSS_SLAVES,
     factory=android_nightly_factory,
     nextBuild=branch_priority,
     category="auto",

--- a/common/map.jinja
+++ b/common/map.jinja
@@ -10,7 +10,6 @@
           'servo-linux-android1': '72.14.176.110',
           'servo-mac1': '208.52.161.130',
           'servo-mac3': '63.135.170.19',
-          'servo-head': '96.126.114.185'
         },
         'ssh_users': [
           'ajeffrey',

--- a/top.sls
+++ b/top.sls
@@ -9,11 +9,6 @@ base:
     - match: grain
     - ubuntu
 
-  'servo-head':
-    - buildbot.slave
-    - servo-build-dependencies
-    - servo-build-dependencies.android
-
   'servo-linux-cross\d+':
     - match: pcre
     - buildbot.slave


### PR DESCRIPTION
This will move the doc and android-nightly builds to the linux reserved and cross builders, respectively.

I suspect we'll still want to redo our nightly infra, but this will at least get us down to only one remaining linode instance (servo-master).

r? @edunham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/269)
<!-- Reviewable:end -->
