### PR TITLE
Master needs a python git package for gitfs

### DIFF
--- a/git/init.sls
+++ b/git/init.sls
@@ -2,4 +2,4 @@
 git:
   pkg.installed:
     - pkgs:
-      - git
+      - python-git


### PR DESCRIPTION
https://docs.saltstack.com/en/2015.5/topics/tutorials/gitfs.html says it's the preferred method. 

It looks like we're not managing any of the salt-master config within salt itself, so this dependency is the only change for #264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/271)
<!-- Reviewable:end -->
