### PR TITLE
Use terse output setting to make Travis logs manageable

### DIFF
--- a/.travis/minion
+++ b/.travis/minion
@@ -1,4 +1,5 @@
 state_output: terse
+state_tabular: True
 file_client: local
 file_roots:
   base:

--- a/.travis/minion
+++ b/.travis/minion
@@ -1,3 +1,4 @@
+state_output: terse
 file_client: local
 file_roots:
   base:


### PR DESCRIPTION
Extracting the SDK in builds such as https://travis-ci.org/servo/saltfs/jobs/118038169 was creating 2755 spurious lines of log output. This setting allows the entire build to complete in around 2.5k lines rather than overflowing Travis's 10k line limit. 

r? @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/273)
<!-- Reviewable:end -->
