### PR TITLE
Allow failures on linux cross1 until travis fixes infra issues on GCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-
+  allow_failures:
+    - env: SALT_NODE_ID=servo-linux-cross1
+  
 before_install:
   - .travis/install_salt -F -c .travis -- "${TRAVIS_OS_NAME}"
 


### PR DESCRIPTION
r? @edunham 

If this succeeds (I am always confused about the allow_failures syntax for this case), we can land all of the stuff that's failing due to the issue with the missing Ubuntu packages 'g++-arm-linux-gnueabihf' & 'g++-aarch64-linux-gnu' from the GCE instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/274)
<!-- Reviewable:end -->
