### PR TITLE
Remove extraneous .tgz to fix ARM rootfs downloads

### DIFF
--- a/servo-build-dependencies/map.jinja
+++ b/servo-build-dependencies/map.jinja
@@ -16,14 +16,14 @@
     'targets': [
       {
         'name': 'arm-linux-gnueabihf',
-        'download_name': 'armhf-trusty-libs.tgz',
+        'download_name': 'armhf-trusty-libs',
         'symlink_name': 'arm-unknown-linux-gnueabihf',
         'version': 'v1',
         'sha512': 'd9a31ed488e4f848efcd07f71aa167fc73252da2a2c3b53ba8216100e2b4302b5ccd273b27c434ad189650652a1877607d328ff6b8e1edb5aa68a8927c617b49'
       },
       {
         'name': 'aarch64-linux-gnu',
-        'download_name': 'arm64-trusty-libs.tgz',
+        'download_name': 'arm64-trusty-libs',
         'symlink_name': 'aarch64-unknown-linux-gnu',
         'version': 'v1',
         'sha512': '6c86097188b70940835b2fc936fe70f01890fae45ba4ef79dcccc6a552ad319dcba23e21d6c849fd9d396e0c2f4476a21c93f9b3d4abb4f34d69f22d18017b1b'


### PR DESCRIPTION
See this comment for context:
https://github.com/servo/saltfs/pull/268#issuecomment-201436029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/278)
<!-- Reviewable:end -->
