### PR TITLE
rust bindgen support

### DIFF
--- a/homu/cfg.toml
+++ b/homu/cfg.toml
@@ -15,6 +15,7 @@ port = 54856
 secret = "{{ pillar["homu"]["web-secret"] }}"
 
 {% set travis_repos = [
+    ('crabtw', 'rust-bindgen'),
     ('servo', 'app_units'),
     ('servo', 'cgl-rs'),
     ('servo', 'cocoa-rs'),


### PR DESCRIPTION
r? @Manishearth @edunham 

I'm still not sure of the best way to handle the fact that we need to hand out a GH webhook secret to arbitrary people to set this up. I suspect we will need to set up homu.servo.org at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/279)
<!-- Reviewable:end -->
