### PR TITLE
Handle multiple (redundant) masters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-    - env: SALT_NODE_ID=servo-master
+    - env: SALT_NODE_ID=servo-master1
       os: linux
       sudo: required
       dist: trusty
   allow_failures:
     - env: SALT_NODE_ID=servo-linux-cross1
-  
+
 before_install:
   - .travis/install_salt -F -c .travis -- "${TRAVIS_OS_NAME}"
 

--- a/top.sls
+++ b/top.sls
@@ -29,7 +29,7 @@ base:
     - servo-build-dependencies
     - xvfb
 
-  'servo-master':
+  'servo-master\d+':
     - git
     - buildbot.master
     - homu


### PR DESCRIPTION
Update the Salt states to handle multiple minions that host masters.
This will allow us to easily enter redundant multimaster mode to handle
switching over our master from Linode to EC2, by using separate IDs for
each machine instead of trying to reuse the `servo-master` ID.

See https://github.com/servo/saltfs/issues/281#issuecomment-202835966 for more details.

I haven't updated the `common/map.jinja` file yet; are we still using these hostnames in the `/etc/hosts` file or is everything happening via DNS lookups?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/284)
<!-- Reviewable:end -->
