### PR TITLE
Add number to the buildmaster salt minion names

### DIFF
--- a/top.sls
+++ b/top.sls
@@ -29,7 +29,7 @@ base:
     - servo-build-dependencies
     - xvfb
 
-  'servo-master':
+  'servo-master\d+':
     - git
     - buildbot.master
     - homu


### PR DESCRIPTION
Workflow for this: 

* Land PR
* pull configs on Linode servo-master
* Edit linode servo-master's `/etc/salt/minion` to s/servo-master/servo-master0
* Possibly jump through the key acceptance hoops
* highstate servo-master0 to make sure it works

r? @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/285)
<!-- Reviewable:end -->
