### PR TITLE
Update android-18 menu entry to 8 for SDK r24

### DIFF
--- a/servo-build-dependencies/android.sls
+++ b/servo-build-dependencies/android.sls
@@ -47,14 +47,10 @@ android-sdk:
     - require:
       - user: servo
   cmd.run:
-    # The arguments to --filter are from running 'android list sdk'
-    # Currently these are:
-    #   platform-tool: Android SDK Platform-tools, revision 23.0.1
-    #   9: SDK Platform Android 4.3.1, API 18, revision 3
     - name: |
         expect -c '
         set timeout -1;
-        spawn {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/tools/android - update sdk --no-ui --filter platform-tool,9;
+        spawn {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/tools/android - update sdk --no-ui --filter platform-tool,android-18;
         expect {
          "Do you accept the license" { exp_send "y\r" ; exp_continue }
          eof


### PR DESCRIPTION
We're ignoring Travis builds for the cross builder and this fix needs to be verified in Vagrant (this VM takes a while to provision unfortunately). We may want to actually try running a build in Vagrant to see if this works.

We updated to Android SDK r24 in November from r23, but did not update
the menu entry to install the android-18 target. The new number comes
from the output of `./android sdk list`.

We need to delete the `/home/servo/android/sdk/r24.4.1` folder before applying this fix to the builders. Ideally this would get checked for by Salt, but currently you can only specify one file for the ` - creates: ` key of `cmd.run`, and our state creates the `platform-tools` dir and the `android-18` dir. I'll open a Salt issue for this.

cc @larsbergstrom, https://github.com/servo/servo/issues/10339

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/290)
<!-- Reviewable:end -->
