### PR TITLE
Re-engage servo-linux-cross1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
       dist: trusty
       language: python
       python: 3.5
-  allow_failures:
-    - env: SALT_NODE_ID=servo-linux-cross1
 
 script: .travis/dispatch.sh
 


### PR DESCRIPTION
Upstream has released new packages for Ubuntu Trusty which resolve
the installation conflicts encountered when installing the ARM g++ packages.

See https://bugs.launchpad.net/ubuntu/+source/gcc-4.8-armhf-cross/+bug/1557205/comments/16
for a comment confirming release of the upstream fix.

This reverts commit aa8435536091a125494786997ab3c408dc3b3386 which was part of #274.

Closes #280.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/291)
<!-- Reviewable:end -->
