### PR TITLE
Target servo-master\d+ with PCRE in the top file

### DIFF
--- a/.travis/test_pillars/top.sls
+++ b/.travis/test_pillars/top.sls
@@ -3,7 +3,8 @@ base:
     - travis
     - buildbot.common
 
-  'servo-master':
+  'servo-master\d+':
+    - match: pcre
     - buildbot.master
     - homu
 

--- a/top.sls
+++ b/top.sls
@@ -30,6 +30,7 @@ base:
     - xvfb
 
   'servo-master\d+':
+    - match: pcre
     - git
     - buildbot.master
     - homu


### PR DESCRIPTION
This fixes the targeting for servo-master\d+ so that the extra states
are actually applied.

I noticed this while reviewing the travis builds for #291.
This was missed in both #284 and #285!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/292)
<!-- Reviewable:end -->
