### PR TITLE
Add check for Python 3.5+ in test script

### DIFF
--- a/test.py
+++ b/test.py
@@ -44,11 +44,17 @@ def run_tests(tests):
 
 
 def main():
+    if sys.version_info < (3, 5):  # We use features introduced in Python 3.5
+        sys.stderr.write('{}: Python 3.5 or later is needed for this script\n'
+                         .format(__file__))
+        return 1
+
     tests = ['lint']  # Only tests that are always safe and meaningful to run
     if len(sys.argv) > 1:
         tests = sys.argv[1:]
 
     return run_tests(tests)
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
The test script uses features introduced in Python 3.5 (namely
os.path.commonpath), but the shebang only specifies python3. Because
Python3.5 is fairly new, it's likely that python3 is not yet Python 3.5
(or later) for many people, so explicitly check for this.

This occured on Travis, requiring an explicit 'python: 3.5' config,
which is what spurred this commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/299)
<!-- Reviewable:end -->
