### PR TITLE
Enable gating on arm64 builds

### DIFF
--- a/homu/cfg.toml
+++ b/homu/cfg.toml
@@ -121,8 +121,8 @@ secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 [repo.servo.buildbot]
 url = "http://build.servo.org"
 secret = "{{ pillar["homu"]["buildbot-secret"] }}"
-builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32"]
-try_builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32"]
+builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64"]
+try_builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64"]
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 


### PR DESCRIPTION
r? @aneeshusa @edunham 

https://github.com/servo/servo/pull/10414 landed, so we now have successful arm64 builds (http://build.servo.org/builders/arm64/builds/136).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/305)
<!-- Reviewable:end -->
