### PR TITLE
Add test to check if Nginx is serving requests

### DIFF
--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -23,6 +23,6 @@ else
 
     # TODO: don't hard-code this
     if [ "${SALT_NODE_ID}" = "servo-master1" ]; then
-        ./test.py sls.buildbot.master
+        ./test.py sls.buildbot.master sls.nginx
     fi
 fi

--- a/tests/sls/nginx/serving.py
+++ b/tests/sls/nginx/serving.py
@@ -1,0 +1,23 @@
+import urllib.request
+import urllib.error
+
+from tests.util import Failure, Success
+
+
+def run():
+    try:
+        urllib.request.urlopen('http://localhost/')
+    except urllib.error.URLError as e:
+        # Can call e.read() if there was a response but the HTTP status code
+        # indicated error; the method is unavailable if a connection could not
+        # be made. Nginx is reverse proxying Homu and Buildbot, which will be
+        # dead on Travis because the test pillar credentials are not valid.
+
+        # Also, we're 'expecting' a string for e.reason (for the connection
+        # refused error case), but it may be another exception instance.
+        if not hasattr(e, 'read'):
+            return Failure("Nginx is not serving requests:", str(e.reason))
+
+    # No need to catch HTTPError or ContentTooShortError specially here
+
+    return Success("Nginx is serving requests")


### PR DESCRIPTION
urllib's error handling is not very helpful for this test, but I'm
using it in an effort to avoid extra dependencies. This only checks
if Nginx is alive and returning requests, not whether the HTTP status
codes indicate success. The reason for this is that the test pillars
we have in the repo are not valid, causing Buildbot and Homu to die
after starting, and thus Nginx returns 502 Bad Gateway errors when it
tries to reverse proxy requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/308)
<!-- Reviewable:end -->
