### PR TITLE
Run compiletest on linux-dev

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -105,6 +105,7 @@ mac_test_env = dict({
 linux_dev_factory = create_servo_factory([
     steps.ShellCommand(command=["./mach", "test-tidy", "--no-progress"], env=linux_headless_env),
     steps.Compile(command=["./mach", "build", "--dev"], env=linux_headless_env),
+    steps.ShellCommand(command=["./mach", "test-compiletest"], env=linux_headless_env),
     steps.ShellCommand(command=["./mach", "test-unit"], env=linux_headless_env),
     steps.Compile(command=["./mach", "build-cef"], env=linux_headless_env),
     steps.Compile(command=["./mach", "build-geckolib"], env=linux_headless_env),


### PR DESCRIPTION
The compiletest test is quick to run and shouldn't increase
build times very much.

Fixes #216.

cc @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/313)
<!-- Reviewable:end -->
