### PR TITLE
Update Salt Homebrew install URL for repo split

### DIFF
--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -17,7 +17,7 @@ install_salt () {
     elif [ "${OS_NAME}" = "osx" ]; then
         printf "$0: installing salt for Mac OS X\n"
         brew update
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew/86efec6695b019762505be440798c46d50ebd738/Library/Formula/saltstack.rb
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/3461c9c74b2f3aba9a6fbd7165823c81dc2b4792/Formula/saltstack.rb
     else
         printf >&2 "$0: unknown operating system ${OS_NAME}\n"
         exit 1


### PR DESCRIPTION
The Homebrew/homebrew repository has recently been split into two
separate repositories, Homebrew/brew for the package manager itself
and Homebrew/homebrew-core for the formulas (packages).
See this homebrew-discuss mailing list post announcing this change:
https://groups.google.com/forum/#!msg/homebrew-discuss/D_weS6pZesg/jLgZj6mUCQAJ

The old raw URL we were using seems to still be available, but it seems
likely this is just due to caching by GitHub and it may disappear at
any time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/314)
<!-- Reviewable:end -->
