### PR TITLE
use bash to run the mach stuff

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -238,8 +238,8 @@ windows_compile_env = dict({'PATH': r'C:\msys64\mingw64\bin;C:\msys64\usr\bin\C:
                            **common_test_env)
 
 windows_factory = create_servo_factory([
-    steps.Compile(command=["./mach", "build", "-d", "-v"], env=windows_compile_env),
-    steps.Compile(command=["./mach", "test-unit"], env=windows_compile_env),
+    steps.Compile(command=["bash", "-l", "-c", "./mach build -d -v"], env=windows_compile_env),
+    steps.Compile(command=["bash", "-l", "-c", "./mach test-unit"], env=windows_compile_env),
 ])
 
 doc_factory = create_servo_factory([


### PR DESCRIPTION
r? @aneeshusa @edunham 

Ugh, I forgot that we need to execute bash.exe in order to run the mach command successfully. See:
https://github.com/servo/servo/blob/master/appveyor.yml#L45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/322)
<!-- Reviewable:end -->
