### PR TITLE
Fix typo in Windows PATH

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -232,7 +232,7 @@ arm64_factory = create_servo_factory([
     steps.Compile(command=["./mach", "build", "--rel", "--target=aarch64-unknown-linux-gnu"], env=arm64_compile_env),
 ])
 
-windows_compile_env = dict({'PATH': r'C:\msys64\mingw64\bin;C:\msys64\usr\bin\C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\Amazon\cfn-bootstrap',
+windows_compile_env = dict({'PATH': r'C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Program Files\Amazon\cfn-bootstrap',
                             'MSYSTEM': 'MINGW64',
                             'MSYS': 'winsymlinks=lnk'},
                            **common_test_env)


### PR DESCRIPTION
r? @edunham @aneeshusa 

Should fix the error:
```
'bash' is not recognized as an internal or external command,
operable program or batch file.
program finished with exit code 1
elapsedTime=0.109000
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/326)
<!-- Reviewable:end -->
