### PR TITLE
Ensure Buildbot master files are owned by servo

### DIFF
--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -30,6 +30,15 @@ buildbot-master:
     - context:
         common: {{ common }}
 
+ownership-{{ common.servo_home }}/buildbot/master:
+  file.directory:
+    - name: {{ common.servo_home }}/buildbot/master
+    - user: servo
+    - group: servo
+    - recurse:
+      - user
+      - group
+
 /etc/init/buildbot-master.conf:
   file.managed:
     - source: salt://{{ tpldir }}/files/buildbot-master.conf


### PR DESCRIPTION
If the Buildbot master is ever erroneously started as root, the
permissions on a variety of files in the Buildbot master dir are
clobbered and the Buildbot master process is unable to access them.
Use a file.directory state to set ownership to servo:servo for the
whole folder, so that a highstate will restore the correct permissions
in case this happens.

Fixes #332. r? @edunham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/334)
<!-- Reviewable:end -->
