### PR TITLE
Ensure basic admin utilities are available

### DIFF
--- a/admin/init.sls
+++ b/admin/init.sls
@@ -1,0 +1,10 @@
+admin-packages:
+  pkg.installed:
+    - pkgs:
+      - tmux
+      {% if grains['os'] != 'MacOS' %}
+      - mosh
+      - screen # Installed by default on OS X
+      {% else %}
+      - mobile-shell
+      {% endif %}

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -5,6 +5,11 @@ python3:
     - pkgs:
       - python3
 
+homu-debugging-packages:
+  pkg.installed:
+    - pkgs:
+      - sqlite3
+
 homu:
   virtualenv.managed:
     - name: /home/servo/homu/_venv

--- a/top.sls
+++ b/top.sls
@@ -2,6 +2,7 @@
 
 base:
   '*':
+    - admin
     - common
     - salt.common
 


### PR DESCRIPTION
These are great tools that are even better together and make remote
administration an absolute delight. They make roaming between networks
seamless, which is something I do regularly.

Note that in order for mosh to work, we need to open some UDP ports; the full range of ports is 60001 to 60999, but we probably only need about 10 ports open (for 10 concurrent sessions) so ports 60001 to 60010. I personally am comfortable with mosh's security story (authentication via regular ssh), but let me know if you're not OK with opening these ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/335)
<!-- Reviewable:end -->
