### PR TITLE
Disable Homebrew Analytics

### DIFF
--- a/osx/init.sls
+++ b/osx/init.sls
@@ -11,3 +11,15 @@
     - group: wheel
     - mode: 644
     - source: salt://{{ tpldir }}/files/profile
+
+# Disable Homebrew Analytics
+# TODO: wrap this up into a proper state that uses the `brew analytics` command
+# instead of directly changing the git configuration
+# (requires either upstreaming this state + updating Salt,
+# or Salting the Salt master)
+# TODO: also ensure the `homebrew.analyticsuuid` setting is unset
+disable-homebrew-analytics:
+  git.config:
+    - name: 'homebrew.analyticsdisabled'
+    - value: 'true'
+    - repo: /usr/local


### PR DESCRIPTION
This is not the most robust of solutions, but will do the job.
A better solution would be a custom Salt state, backed by a custom
Salt module, that uses the `brew analytics` command to stay decoupled
from implementation details.

Instead, directly change the git config settings of the local
Homebrew repo to disable analytics.

Fixes #340.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/361)
<!-- Reviewable:end -->
