### PR TITLE
Add caching of Cargo and Rust bits to Windows

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -29,6 +29,7 @@ build_common = Environment({
 })
 
 build_windows = build_common + Environment({
+    'CARGO_HOME': r'C:\msys64\home\Administrator\.cargo',
     'MSYS': 'winsymlinks=lnk',
     'MSYSTEM': 'MINGW64',
     'PATH': ';'.join([
@@ -40,6 +41,7 @@ build_windows = build_common + Environment({
         r'C:\Windows\System32\WindowsPowerShell\v1.0',
         r'C:\Program Files\Amazon\cfn-bootstrap',
     ]),
+    'SERVO_CACHE_DIR': r'c:\msys64\home\Administrator\.servo',
 })
 
 build_mac = build_common + Environment({


### PR DESCRIPTION
r? @edunham @aneeshusa 

Fixes #358

I decided to use the msys home dir instead of `%APPDATA%` for consistency with the other unix builds, but could be convinced otherwise if we get to a point where Servo is not building inside of the msys/mingw environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/362)
<!-- Reviewable:end -->
