### PR TITLE
Use uppercase drive letter for SERVO_CACHE_DIR

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -41,7 +41,7 @@ build_windows = build_common + Environment({
         r'C:\Windows\System32\WindowsPowerShell\v1.0',
         r'C:\Program Files\Amazon\cfn-bootstrap',
     ]),
-    'SERVO_CACHE_DIR': r'c:\msys64\home\Administrator\.servo',
+    'SERVO_CACHE_DIR': r'C:\msys64\home\Administrator\.servo',
 })
 
 build_mac = build_common + Environment({


### PR DESCRIPTION
Windows apparently doesn't recognize lowercase drive letters.

r? @larsbergstrom @edunham (To get Windows working again)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/363)
<!-- Reviewable:end -->
