### PR TITLE
Eight processes causes more intermittents to be hit; reverting to four.

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -17,7 +17,7 @@ mac-dev-unit:
 
 mac-rel-css:
   - ./mach build --release
-  - ./mach test-css --release --processes 8 --log-raw test-css.log --log-errorsummary css-errorsummary.log
+  - ./mach test-css --release --processes 4 --log-raw test-css.log --log-errorsummary css-errorsummary.log
   - ./mach build-geckolib --release
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh


### PR DESCRIPTION
r? @edunham @aneeshusa 

It looks like we're hitting the intermittents way more often and, unlike test-wpt, this doesn't save as much time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/367)
<!-- Reviewable:end -->
