### PR TITLE
Enable caching deps on Windows, this time with UNIX paths

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -29,6 +29,7 @@ build_common = Environment({
 })
 
 build_windows = build_common + Environment({
+    'CARGO_HOME': '/home/Administrator/.cargo',
     'MSYS': 'winsymlinks=lnk',
     'MSYSTEM': 'MINGW64',
     'PATH': ';'.join([
@@ -40,6 +41,7 @@ build_windows = build_common + Environment({
         r'C:\Windows\System32\WindowsPowerShell\v1.0',
         r'C:\Program Files\Amazon\cfn-bootstrap',
     ]),
+    'SERVO_CACHE_DIR': '/home/Administrator/.servo',
 })
 
 build_mac = build_common + Environment({


### PR DESCRIPTION
r? @aneeshusa @edunham 

*this* time, I tested it locally on the build machine itself inside of a MINGW64 shell that I believe reproduces the exact environment, and it seemed to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/370)
<!-- Reviewable:end -->
