### PR TITLE
Switch to fresh method for the buildbot Git step

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -23,7 +23,8 @@ class ServoFactory(util.BuildFactory):
         Prefer using DynamicServoFactory to using this class directly.
         """
         all_steps = [
-            steps.Git(repourl=SERVO_REPO, mode="full", method="clobber"),
+            steps.Git(repourl=SERVO_REPO,
+                      mode="full", method="fresh", retryFetch=True),
         ] + build_steps
         # util.BuildFactory is an old-style class so we cannot use super()
         # but must hardcode the superclass here


### PR DESCRIPTION
This switches from method=clobber to method=fresh, which means instead
of a completely full new clone, we will run git clean -fxxd to reset the
tree and use git fetch to synchronize the repository. This also adds a
single retry on failure for the git fetch step. Failure of the git clean
step will result in a full reclone.

This should alleviate CI failures related to git clone errors, and also
make the step slightly faster and quite a bit lighter on the network load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/371)
<!-- Reviewable:end -->
