### PR TITLE
Enable a non-gated gczeal builder

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -59,10 +59,6 @@ build_linux = build_common + Environment({
     'SHELL': '/bin/bash',
 })
 
-build_linux_headless = build_linux + Environment({
-    'SERVO_HEADLESS': '1',
-})
-
 build_android = build_linux + Environment({
     'ANDROID_NDK': '{{ common.servo_home }}/android/ndk/current/',
     'ANDROID_SDK': '{{ common.servo_home }}/android/sdk/current/',

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -135,8 +135,8 @@ class DynamicServoBuilder(util.BuilderConfig):
 
 
 c['builders'] = [
-    DynamicServoBuilder("linux-dev", LINUX_SLAVES, envs.build_linux_headless),
-    DynamicServoBuilder("linux-rel", LINUX_SLAVES, envs.build_linux_headless),
+    DynamicServoBuilder("linux-dev", LINUX_SLAVES, envs.build_linux),
+    DynamicServoBuilder("linux-rel", LINUX_SLAVES, envs.build_linux),
     DynamicServoBuilder("android", CROSS_SLAVES, envs.build_android),
     DynamicServoBuilder("arm32", CROSS_SLAVES, envs.build_arm32),
     DynamicServoBuilder("arm64", CROSS_SLAVES, envs.build_arm64),

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -8,7 +8,7 @@ from passwords import SLAVE_PASSWORD, CHANGE_PASSWORD
 from passwords import HOMU_BUILDBOT_SECRET
 
 
-LINUX_SLAVES = ["servo-linux1", "servo-linux2"]
+LINUX_SLAVES = ["servo-linux1", "servo-linux2", "servo-linux3"]
 MAC_SLAVES = ["servo-mac1", "servo-mac2", "servo-mac3", "servo-macpro1"]
 CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
 WINDOWS_SLAVES = ["servo-windows1"]
@@ -65,6 +65,7 @@ c['schedulers'].append(schedulers.AnyBranchScheduler(
     builderNames=[
         "linux-dev",
         "linux-rel",
+        "linux-rel-gczeal",
         "mac-rel-wpt",
         "mac-dev-unit",
         "mac-rel-css",
@@ -86,6 +87,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
     builderNames=[
         "linux-dev",
         "linux-rel",
+        "linux-rel-gczeal",
         "mac-rel-wpt",
         "mac-dev-unit",
         "mac-rel-css",
@@ -137,6 +139,7 @@ class DynamicServoBuilder(util.BuilderConfig):
 c['builders'] = [
     DynamicServoBuilder("linux-dev", LINUX_SLAVES, envs.build_linux),
     DynamicServoBuilder("linux-rel", LINUX_SLAVES, envs.build_linux),
+    DynamicServoBuilder("linux-rel-gczeal", LINUX_SLAVES, envs.build_linux),
     DynamicServoBuilder("android", CROSS_SLAVES, envs.build_android),
     DynamicServoBuilder("arm32", CROSS_SLAVES, envs.build_arm32),
     DynamicServoBuilder("arm64", CROSS_SLAVES, envs.build_arm64),

--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -45,6 +45,13 @@ linux-rel:
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
+linux-rel-gczeal:
+  - ./mach build --release --debug-mozjs
+  - ./mach test-wpt --release --processes 24 --pref js.mem.gc.zeal.level=2 --pref js.mem.gc.zeal.frequency=1 --log-raw test-wpt-every-alloc.log --log-errorsummary wpt-errorsummary-every-alloc.log
+  - ./mach test-wpt --release --processes 24 --pref js.mem.gc.zeal.level=2 --pref js.mem.gc.zeal.frequency=100 --log-raw test-wpt-every-hundred.log --log-errorsummary wpt-errorsummary-every-hundred.log
+  - ./mach test-wpt --release --processes 24 --pref js.mem.gc.zeal.level=4 --pref js.mem.gc.zeal.frequency=1 --log-raw test-wpt-pre-barriers.log --log-errorsummary wpt-errorsummary-pre-barriers.log
+  - ./mach test-wpt --release --processes 24 --pref js.mem.gc.zeal.level=11 --pref js.mem.gc.zeal.frequency=1 --log-raw test-wpt-post-barriers.log --log-errorsummary wpt-errorsummary-post-barriers.log
+
 android:
   - ./mach build --android --dev
   - bash ./etc/ci/lockfile_changed.sh


### PR DESCRIPTION
This adds a new `linux-rel-gczeal` builder, but does *not* currently gate builds on it. It builds release servo with debug mozjs and then runs the WPT tests with four different debug-mode GC settings to stress our bindings.

It is not currently gated because I have no idea how reliable these tests will be.

I've also added another EC2 instance (servo-linux3) for use by this. Note that we're out of static IPs for our account, so you have to go to the EC2 console to get the temp IP and we can't really assign it to a static .servo.org address.

r? @edunham @aneeshusa 

cc @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/373)
<!-- Reviewable:end -->
