### PR TITLE
Use --all flag when running `./mach test-tidy`

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -23,7 +23,7 @@ mac-rel-css:
   - bash ./etc/ci/manifest_changed.sh
 
 linux-dev:
-  - ./mach test-tidy --no-progress
+  - ./mach test-tidy --no-progress --all
   - ./mach test-tidy --no-progress --self-test
   - ./mach build --dev
   - ./mach test-compiletest


### PR DESCRIPTION
[`./mach test-tidy` should be `--faster` by default](https://github.com/servo/servo/issues/11217).
However, the [CI server should still check everything using the `--all` flag](https://github.com/servo/servo/pull/11267#issuecomment-220337310).

This PR changes the CI server to use the `--all` flag, but shouldn't be merged until Servo's [`11267`](https://github.com/servo/servo/pull/11267) gets merged, because `11267` adds `--all`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/377)
<!-- Reviewable:end -->
