### PR TITLE
Ensure specific Android SDK platform version is installed

### DIFF
--- a/servo-build-dependencies/android.sls
+++ b/servo-build-dependencies/android.sls
@@ -50,14 +50,16 @@ android-sdk:
     - name: |
         expect -c '
         set timeout -1;
-        spawn {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/tools/android - update sdk --no-ui --filter platform-tool,android-18;
+        spawn {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/tools/android - update sdk --no-ui --filter platform-tool,android-{{ android.platform }};
         expect {
          "Do you accept the license" { exp_send "y\r" ; exp_continue }
          eof
         }
         '
     - user: servo
-    - creates: {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/platform-tools
+    - creates:
+      - {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/platform-tools
+      - {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/platforms/android-{{ android.platform }}
     - require:
       - pkg: android-dependencies
       - archive: android-sdk
@@ -95,7 +97,7 @@ android-ndk:
 
 android-toolchain:
   cmd.run:
-    - name: bash {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}/build/tools/make-standalone-toolchain.sh --platform=android-18 --toolchain=arm-linux-androideabi-4.8 --install-dir='{{ common.servo_home }}/android/toolchain/{{ android.ndk.version }}/android-toolchain' --ndk-dir='{{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}'
+    - name: bash {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}/build/tools/make-standalone-toolchain.sh --platform=android-{{ android.platform }} --toolchain=arm-linux-androideabi-4.8 --install-dir='{{ common.servo_home }}/android/toolchain/{{ android.ndk.version }}/android-toolchain' --ndk-dir='{{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}'
     - user: servo
     - creates: {{ common.servo_home }}/android/toolchain/{{ android.ndk.version }}/android-toolchain
     - require:

--- a/servo-build-dependencies/map.jinja
+++ b/servo-build-dependencies/map.jinja
@@ -1,5 +1,6 @@
 {%
   set android = {
+    'platform': '18',
     'sdk': {
       'version': 'r24.4.1',
       'sha512': '96fb71d78a8c2833afeba6df617edcd6cc4e37ecd0c3bec38c39e78204ed3c2bd54b138a56086bf5ccd95e372e3c36e72c1550c13df8232ec19537da93049284'


### PR DESCRIPTION
Update the creates parameter to the cmd.run state which installs the
Android SDK to check for both the platform tools and the specific
version of the platform we are using (currently, android-18). This
makes sure that the SDK will reinstalled on future Salt runs if either
directory is missing, instead of just checking for the platform tools.

Also, extract the Android platform into a Jinja variable.

Note that this feature of Salt is not documented, hence why I didn't
do this originally - I thought it didn't exist. I only discovered it
when I went into the Salt codebase to implement it myself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/383)
<!-- Reviewable:end -->
