### PR TITLE
Use reduced set of builders for try builds

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -46,65 +46,77 @@ c['change_source'] = [changes.PBChangeSource(passwd=CHANGE_PASSWORD)]
 ##################
 
 
-def servo_auto_try_filter(c):
-    return (c.project == 'servo/servo' and
-            c.who.startswith('bors-servo') and
-            c.branch in ["auto", "try"])
+def servo_branch_filter(branch):
+    def customized_filter(change):
+        return (change.project == 'servo/servo' and
+                change.who.startswith('bors-servo') and
+                change.branch == branch)
+
+    return util.ChangeFilter(filter_fn=customized_filter)
 
 
-def servo_master_filter(c):
-    return (c.project == 'servo/servo' and
-            c.who.startswith('bors-servo') and
-            c.branch == "master")
-
-
-c['schedulers'] = []
-c['schedulers'].append(schedulers.AnyBranchScheduler(
-    name="servo-auto",
-    treeStableTimer=None,
-    builderNames=[
-        "linux-dev",
-        "linux-rel",
-        "linux-rel-gczeal",
-        "mac-rel-wpt",
-        "mac-dev-unit",
-        "mac-rel-css",
-        "android",
-        "arm32",
-        "arm64",
-        "windows",
-    ],
-    change_filter=util.ChangeFilter(filter_fn=servo_auto_try_filter),
-))
-c['schedulers'].append(schedulers.SingleBranchScheduler(
-    name="doc-push",
-    treeStableTimer=None,
-    builderNames=["doc"],
-    change_filter=util.ChangeFilter(filter_fn=servo_master_filter),
-))
-c['schedulers'].append(schedulers.ForceScheduler(
-    name="force",
-    builderNames=[
-        "linux-dev",
-        "linux-rel",
-        "linux-rel-gczeal",
-        "mac-rel-wpt",
-        "mac-dev-unit",
-        "mac-rel-css",
-        "android",
-        "arm32",
-        "arm64",
-        "android-nightly",
-        "windows",
-    ],
-))
-c['schedulers'].append(schedulers.Nightly(
-    name="Nightly",
-    branch="master",
-    builderNames=["android-nightly"],
-    hour=1,
-    minute=0,
-))
+c['schedulers'] = [
+    schedulers.AnyBranchScheduler(
+        name="servo-auto",
+        treeStableTimer=None,
+        builderNames=[  # Run the full set of builds
+            "linux-dev",
+            "linux-rel",
+            "linux-rel-gczeal",
+            "mac-rel-wpt",
+            "mac-dev-unit",
+            "mac-rel-css",
+            "android",
+            "arm32",
+            "arm64",
+            "windows",
+        ],
+        change_filter=servo_branch_filter('auto'),
+    ),
+    schedulers.AnyBranchScheduler(
+        name="servo-try",
+        treeStableTimer=None,
+        builderNames=[  # Run a reduced set of builds for speed
+            "linux-dev",
+            "linux-rel",
+            "mac-rel-wpt",
+            "mac-rel-css",
+            "android",
+            "arm64",
+            "windows",
+        ],
+        change_filter=servo_branch_filter('try'),
+    ),
+    schedulers.SingleBranchScheduler(
+        name="doc-push",
+        treeStableTimer=None,
+        builderNames=["doc"],
+        change_filter=servo_branch_filter('master'),
+    ),
+    schedulers.ForceScheduler(
+        name="force",
+        builderNames=[
+            "linux-dev",
+            "linux-rel",
+            "linux-rel-gczeal",
+            "mac-rel-wpt",
+            "mac-dev-unit",
+            "mac-rel-css",
+            "android",
+            "arm32",
+            "arm64",
+            "android-nightly",
+            "windows",
+        ],
+    ),
+    schedulers.Nightly(
+        name="Nightly",
+        branch="master",
+        builderNames=["android-nightly"],
+        hour=1,
+        minute=0,
+    ),
+]
 
 
 ##################


### PR DESCRIPTION
Running all the builds for try builds is unnecessary and uses up extra
resources, slowing down the rate of queue drainage. In particular,
the recently-added linux-rel-gczeal build takes a long time, but is not
yet gated on, and adds no value being run for try builds. Reduce the set
of builders for try builds down to a minimal set that still has full
platform coverage.

cc @metajack @mbrubeck
Conversation on IRC: http://logs.glob.uno/?c=mozilla%23servo&s=25+May+2016&e=25+May+2016#c439048

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/384)
<!-- Reviewable:end -->
