### PR TITLE
Test packaging on android builder

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -47,6 +47,7 @@ linux-rel:
 
 android:
   - ./mach build --android --dev
+  - ./mach package --android --dev
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
   - python ./etc/ci/check_dynamic_symbols.py


### PR DESCRIPTION
Our android-nightly builder has been busted for a long time, which meant
our packaging code was not being exercised. Also, the nightly builder
only runs once a day instead of on each build, which recently allowed
a regression to slip in due to an uncaught syntax error. To prevent
future regressions, test packaging on the android builder, which runs
on try and auto builds.

See https://github.com/servo/servo/pull/11406 for the bug.
This should not be merged until that fix is merged and android-nightly has
had a chance to run, to ensure that packaging is no longer broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/386)
<!-- Reviewable:end -->
