### PR TITLE
Use buildbot GitHub status integration

### DIFF
--- a/.travis/test_pillars/buildbot/master.sls
+++ b/.travis/test_pillars/buildbot/master.sls
@@ -5,6 +5,7 @@ buildbot:
     'change-pass': 'TEST_BUILDBOT_CHANGE_PASS'
     'gh-doc-token': 'TEST_BUILDBOT_GH_DOC_TOKEN'
     'gh-hook-secret': 'TEST_BUILDBOT_GH_HOOK_SECRET'
+    'gh-status-token': 'TEST_BUILDBOT_GH_STATUS_TOKEN'
     'homu-secret': 'TEST_BUILDBOT_HOMU_SECRET'
     's3-upload-access-key-id': 'TEST_BUILDBOT_S3_UPLOAD_ACCESS_KEY_ID'
     's3-upload-secret-access-key': 'TEST_BUILDBOT_S3_UPLOAD_SECRET_ACCESS_KEY'

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -1,11 +1,11 @@
-from buildbot.plugins import buildslave, changes, schedulers, util
+from buildbot.plugins import buildslave, changes, schedulers, status, util
 from buildbot.status import html, status_push, web, words
 
 import environments as envs
 import factories
 from passwords import HTTP_USERNAME, HTTP_PASSWORD
 from passwords import SLAVE_PASSWORD, CHANGE_PASSWORD
-from passwords import HOMU_BUILDBOT_SECRET
+from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
 LINUX_SLAVES = ["servo-linux1", "servo-linux2", "servo-linux3"]
@@ -190,35 +190,45 @@ c['builders'] = [
 ##################
 
 
-c['status'] = []
-c['status'].append(status_push.HttpStatusPush(
-    serverUrl='http://build.servo.org:54856/buildbot',
-    extra_post_params={'secret': HOMU_BUILDBOT_SECRET},
-))
-
-authz_cfg = web.authz.Authz(
-    auth=web.auth.BasicAuth([(HTTP_USERNAME, HTTP_PASSWORD)]),
-    gracefulShutdown='auth',
-    forceBuild='auth',
-    forceAllBuilds='auth',
-    pingBuilder='auth',
-    stopBuild='auth',
-    stopAllBuilds='auth',
-    cancelPendingBuild='auth',
-)
-c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))
-
-c['status'].append(words.IRC(host="irc.mozilla.org",
-                             port=6697,
-                             useSSL=True,
-                             nick="servo_buildbot",
-                             channels=["#servo-bots"],
-                             notify_events={
-                                 'exception': 1,
-                                 'finished': 1,
-                                 'success': 1,
-                                 'failure': 1,
-                             }))
+c['status'] = [
+    status_push.HttpStatusPush(
+        serverUrl='http://build.servo.org:54856/buildbot',
+        extra_post_params={'secret': HOMU_BUILDBOT_SECRET},
+    ),
+    html.WebStatus(
+        http_port=8010,
+        authz=web.authz.Authz(
+            auth=web.auth.BasicAuth([(HTTP_USERNAME, HTTP_PASSWORD)]),
+            gracefulShutdown='auth',
+            forceBuild='auth',
+            forceAllBuilds='auth',
+            pingBuilder='auth',
+            stopBuild='auth',
+            stopAllBuilds='auth',
+            cancelPendingBuild='auth',
+        ),
+    ),
+    status.GitHubStatus(
+        token=GITHUB_STATUS_TOKEN,
+        repoOwner='servo',
+        repoName='servo',
+        startDescription="Build started.",
+        endDescription="Build done.",
+    ),
+    words.IRC(
+        host="irc.mozilla.org",
+        port=6697,
+        useSSL=True,
+        nick="servo_buildbot",
+        channels=["#servo-bots"],
+        notify_events={
+            'exception': 1,
+            'finished': 1,
+            'success': 1,
+            'failure': 1,
+        },
+    ),
+]
 
 
 ##################

--- a/buildbot/master/files/config/passwords.py
+++ b/buildbot/master/files/config/passwords.py
@@ -1,18 +1,11 @@
-import json
-
-# Jinja will replace the inside with double-quote-using JSON,
-# so use single quotes to delimit the string.
-# Use double quotes inside to keep the expression as a single string.
-credentials = json.loads('{{ pillar["buildbot"]["credentials"]|json }}')
-# json.loads creates unicode strings but Buildbot requires bytestrings.
-# Python 2's Unicode situation makes me sad.
-credentials = {k: v.encode('utf-8') for k, v in credentials.items()}
-
-HTTP_USERNAME = credentials['http-user']
-HTTP_PASSWORD = credentials['http-pass']
-SLAVE_PASSWORD = credentials['slave-pass']
-CHANGE_PASSWORD = credentials['change-pass']
-GITHUB_DOC_TOKEN = credentials['gh-doc-token']
-HOMU_BUILDBOT_SECRET = credentials['homu-secret']
-S3_UPLOAD_ACCESS_KEY_ID = credentials['s3-upload-access-key-id']
-S3_UPLOAD_SECRET_ACCESS_KEY = credentials['s3-upload-secret-access-key']
+HTTP_USERNAME = "{{ buildbot_credentials['http-user'] }}"
+HTTP_PASSWORD = "{{ buildbot_credentials['http-pass'] }}"
+SLAVE_PASSWORD = "{{ buildbot_credentials['slave-pass'] }}"
+CHANGE_PASSWORD = "{{ buildbot_credentials['change-pass'] }}"
+GITHUB_DOC_TOKEN = "{{ buildbot_credentials['gh-doc-token'] }}"
+HOMU_BUILDBOT_SECRET = "{{ buildbot_credentials['homu-secret'] }}"
+S3_UPLOAD_ACCESS_KEY_ID = \
+    "{{ buildbot_credentials['s3-upload-access-key-id'] }}"
+S3_UPLOAD_SECRET_ACCESS_KEY = \
+    "{{ buildbot_credentials['s3-upload-secret-access-key'] }}"
+GITHUB_STATUS_TOKEN = "{{ buildbot_credentials['gh-status-token'] }}"

--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -29,6 +29,7 @@ buildbot-master:
     - template: jinja
     - context:
         common: {{ common }}
+        buildbot_credentials: {{ pillar['buildbot']['credentials'] }}
 
 ownership-{{ common.servo_home }}/buildbot/master:
   file.directory:


### PR DESCRIPTION
Buildbot 0.8.12 has a GitHub status integration; it would be better to
use that directly instead of making Homu act as a middleman. Note that
this commit does not change the Homu configuration, but only adds a
GitHub status integration for Buildbot.

Note that this requires a new secret value in the Pillar - a token
that Buildbot can use to access the GitHub status API.

See http://docs.buildbot.net/current/manual/cfg-statustargets.html#githubstatus
for more details on the integration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/387)
<!-- Reviewable:end -->
