### PR TITLE
Install Android build tools for cross compilation

### DIFF
--- a/servo-build-dependencies/android.sls
+++ b/servo-build-dependencies/android.sls
@@ -50,7 +50,7 @@ android-sdk:
     - name: |
         expect -c '
         set timeout -1;
-        spawn {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/tools/android - update sdk --no-ui --filter platform-tool,android-{{ android.platform }};
+        spawn {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/tools/android - update sdk --no-ui --all --filter platform-tools,android-{{ android.platform }},build-tools-{{ android.build_tools }};
         expect {
          "Do you accept the license" { exp_send "y\r" ; exp_continue }
          eof
@@ -60,6 +60,7 @@ android-sdk:
     - creates:
       - {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/platform-tools
       - {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/platforms/android-{{ android.platform }}
+      - {{ common.servo_home }}/android/sdk/{{ android.sdk.version }}/android-sdk-linux/build-tools/{{ android.build_tools }}
     - require:
       - pkg: android-dependencies
       - archive: android-sdk

--- a/servo-build-dependencies/map.jinja
+++ b/servo-build-dependencies/map.jinja
@@ -1,5 +1,6 @@
 {%
   set android = {
+    'build_tools': '23.0.3',
     'platform': '18',
     'sdk': {
       'version': 'r24.4.1',


### PR DESCRIPTION
The Android build tools are required for building an APK.
They are versioned separately from the SDK and do not have a version
requirement - best practice is to use the latest (stable) release.

After servo/servo#11406 landed, I forced an android-nightly build, which now gets further but still fails. The new failure is http://build.servo.org/builders/android-nightly/builds/60/steps/shell_1/logs/stdio, so install the build tools to fix this.

Edit: relevant error for posterity:
```
BUILD FAILED
/home/servo/android/sdk/current/tools/ant/build.xml:483: SDK does not have any Build Tools installed.
```

Another step for servo/servo#10339.

I think this would benefit from #374 - I had a lot of errors trying to get the android tool to install the build tools where blowing away the directory fixed it. I think the --all parameter should take care of it, but I'd like to be more sure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/388)
<!-- Reviewable:end -->
