### PR TITLE
Install freetype on OSX

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -10,6 +10,7 @@ servo-dependencies:
       - automake
       - pkg-config
       - openssl
+      - freetype
       {% else %}
       - libglib2.0-dev
       - libgl1-mesa-dri


### PR DESCRIPTION
To fix this broken Mac build: https://github.com/servo/servo/pull/11649#issuecomment-224275471

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/393)
<!-- Reviewable:end -->
