### PR TITLE
Remove Angle gating on appveyor

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -160,8 +160,5 @@ master = "servo"
 
 # Additional AppVeyor testing for relevant repos
 
-[repo.angle.status.appveyor]
-context = 'continuous-integration/appveyor/branch'
-
 [repo.ipc-channel.status.appveyor]
 context = 'continuous-integration/appveyor/branch'


### PR DESCRIPTION
It seems to depend on the `__cpuid` intrinsic only exposed by MSVC
for windows, so my quick [attempt](https://github.com/servo/angle/pull/11)
to make it build with mingw has failed.

Will probably try again later (so please don't remove the hook), but
removing the gate seems worth it so pending PRs can merge while I
experiment with that :)

r? @larsbergstrom / @aneeshusa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/395)
<!-- Reviewable:end -->
