### PR TITLE
Add --android option to ./mach package

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -53,7 +53,7 @@ android:
 
 android-nightly:
   - ./mach build --android --release
-  - ./mach package -r
+  - ./mach package --android --release
   - s3cmd put target/arm-linux-androideabi/release/servo.apk s3://servo-rust/nightly/servo.apk
 
 arm32:


### PR DESCRIPTION
https://github.com/servo/servo/pull/11210 recently updated `./mach
package` to make it a first-class Mach command and add support for
simple Linux packaging as well (in the form of tarballs). Android used
to be the only packaging target supported, so a naked `./mach package`
sufficed, but now we need to explicitly build the Android packaging.

Another step for servo/servo#10339.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/401)
<!-- Reviewable:end -->
