### PR TITLE
Remove duplicate repo

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -15,7 +15,6 @@ port = 54856
 secret = "{{ pillar["homu"]["web-secret"] }}"
 
 {% set travis_repos = [
-    ('crabtw', 'rust-bindgen'),
     ('servo', 'angle'),
     ('servo', 'app_units'),
     ('servo', 'cgl-rs'),


### PR DESCRIPTION
the two rust-bindgens combine to make an invalid toml file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/405)
<!-- Reviewable:end -->
