### PR TITLE
Fix json's anger at newlines

### DIFF
--- a/buildbot/master/files/config/passwords.py
+++ b/buildbot/master/files/config/passwords.py
@@ -3,7 +3,8 @@ import json
 # Jinja will replace the inside with double-quote-using JSON,
 # so use single quotes to delimit the string.
 # Use double quotes inside to keep the expression as a single string.
-credentials = json.loads('{{ pillar["buildbot"]["credentials"]|json }}')
+credentials = json.loads('{{ pillar["buildbot"]["credentials"]|json }}',
+                         strict=False)
 # json.loads creates unicode strings but Buildbot requires bytestrings.
 # Python 2's Unicode situation makes me sad.
 credentials = {k: v.encode('utf-8') for k, v in credentials.items()}


### PR DESCRIPTION
Error without this fix:

```
credentials = json.loads('{...}')
      File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
        return _default_decoder.decode(s)
      File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
        obj, end = self.scan_once(s, idx)
    exceptions.ValueError: Invalid control character at: line 1 column 444 (char 443)
```

note: line 1 column 444 of the giant blob of secrets that I elided is the first occurrence of `\n` in the string.

Reason I think this works: Testing it in prod (sorry!) and also
http://stackoverflow.com/questions/9295439/python-json-loads-fails-with-valueerror-invalid-control-character-at-line-1-c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/415)
<!-- Reviewable:end -->
