### PR TITLE
Fix windows-nightly upload step

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -121,3 +121,5 @@ upload_nightly = Environment({
     'AWS_ACCESS_KEY_ID': S3_UPLOAD_ACCESS_KEY_ID,
     'AWS_SECRET_ACCESS_KEY': S3_UPLOAD_SECRET_ACCESS_KEY,
 })
+
+upload_nightly_windows = build_windows + upload_nightly

--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -253,6 +253,6 @@ windows_nightly = ServoFactory([
     steps.Compile(command=make_win_command(
                       "./etc/ci/upload_nightly.sh windows"
                   ),
-                  env=envs.upload_nightly,
+                  env=envs.upload_nightly_windows,
                   logEnviron=False),
 ])


### PR DESCRIPTION
This _should_ fix missing bash command in upload step on ``windows-nightly``

CC @aneeshusa @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/418)
<!-- Reviewable:end -->
