### PR TITLE
Removed Buildbot Categories

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -140,7 +140,6 @@ class DynamicServoBuilder(util.BuilderConfig):
             slavenames=slavenames,
             factory=factories.DynamicServoFactory(name, environment),
             nextBuild=branch_priority,
-            category="auto",
         )
 
 
@@ -158,7 +157,6 @@ class DynamicServoYAMLBuilder(util.BuilderConfig):
             slavenames=slavenames,
             factory=factories.DynamicServoYAMLFactory(name, environment),
             nextBuild=branch_priority,
-            category="auto",
         )
 
 c['builders'] = [
@@ -179,20 +177,17 @@ c['builders'] = [
         slavenames=WINDOWS_SLAVES,
         factory=factories.windows,
         nextBuild=branch_priority,
-        category="auto",
     ),
     util.BuilderConfig(
         name="windows-nightly",
         slavenames=WINDOWS_SLAVES,
         factory=factories.windows_nightly,
         nextBuild=branch_priority,
-        category="auto",
     ),
     util.BuilderConfig(
         name="doc",
         slavenames=LINUX_SLAVES,
         factory=factories.doc,
-        category="auto",
     ),
     # Testing the In Tree YAML build
     DynamicServoYAMLBuilder("linux-dev-yaml", LINUX_SLAVES,


### PR DESCRIPTION
Addresses Issue: https://github.com/servo/saltfs/issues/412

Removed unused categories on the builders.

Additionally  the `categories` parameter was deprecated in Buildbot 0.8.12 (the version currently in use)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/419)
<!-- Reviewable:end -->
