### PR TITLE
Pre-split cat step.yml command

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -130,9 +130,8 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
     @defer.inlineCallbacks
     def run(self):
         try:
-            print_yaml_cmd = "cat {}".format(self.yaml_path)
             cmd = yield self.makeRemoteShellCommand(
-                command=[print_yaml_cmd],
+                command=["cat", "./{}".format(self.yaml_path)],
                 collectStdout=True
             )
             yield self.runCommand(cmd)


### PR DESCRIPTION
We are passing the command as an array, so we need to pre-split the
command into separate words.

Naughtily tested in prod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/424)
<!-- Reviewable:end -->
