### PR TITLE
Add notriddle as reviewer

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -86,6 +86,7 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
     "michaelwu",
     "mrobinson",
     "Ms2ger",
+    "notriddle",
     "nox",
     "pcwalton",
     "saneyuki",


### PR DESCRIPTION
For a couple of PRs now, I've been given permission to review them but not delegated. Let's make this a bit simpler.

Should I go in the "operators" list instead?

[Somewhat relevant IRC discussion.](http://logs.glob.uno/?c=mozilla%23servo&s=4+Jul+2016&e=5+Jul+2016#c473368)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/425)
<!-- Reviewable:end -->
