### PR TITLE
Convert Windows builders to use DynamicServoFactory

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -31,6 +31,8 @@ build_common = Environment({
 
 build_windows = build_common + Environment({
     'CARGO_HOME': '/home/Administrator/.cargo',
+    # Set home directory, to avoid adding `cd` command on every command
+    'HOME': r'C:\buildbot\slave\windows\build',
     'MSYS': 'winsymlinks=lnk',
     'MSYSTEM': 'MINGW64',
     'PATH': ';'.join([

--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -123,5 +123,3 @@ upload_nightly = Environment({
     'AWS_ACCESS_KEY_ID': S3_UPLOAD_ACCESS_KEY_ID,
     'AWS_SECRET_ACCESS_KEY': S3_UPLOAD_SECRET_ACCESS_KEY,
 })
-
-upload_nightly_windows = build_windows + upload_nightly

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -171,19 +171,9 @@ c['builders'] = [
     DynamicServoBuilder("mac-nightly", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("mac-rel-css", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("mac-rel-wpt", MAC_SLAVES, envs.build_mac),
+    DynamicServoBuilder("windows", WINDOWS_SLAVES, envs.build_windows),
+    DynamicServoBuilder("windows-nightly", WINDOWS_SLAVES, envs.build_windows),
     # The below builders are not dynamic but rather have hard-coded factories
-    util.BuilderConfig(
-        name="windows",
-        slavenames=WINDOWS_SLAVES,
-        factory=factories.windows,
-        nextBuild=branch_priority,
-    ),
-    util.BuilderConfig(
-        name="windows-nightly",
-        slavenames=WINDOWS_SLAVES,
-        factory=factories.windows_nightly,
-        nextBuild=branch_priority,
-    ),
     util.BuilderConfig(
         name="doc",
         slavenames=LINUX_SLAVES,

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -72,7 +72,7 @@ c['schedulers'].append(schedulers.AnyBranchScheduler(
         "mac-dev-unit",
         "mac-rel-css",
         "mac-rel-wpt",
-        "windows",
+        "windows-dev",
     ],
     change_filter=util.ChangeFilter(filter_fn=servo_auto_try_filter),
 ))
@@ -97,7 +97,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
         "mac-nightly",
         "mac-rel-css",
         "mac-rel-wpt",
-        "windows",
+        "windows-dev",
         "windows-nightly",
     ],
 ))
@@ -171,7 +171,7 @@ c['builders'] = [
     DynamicServoBuilder("mac-nightly", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("mac-rel-css", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("mac-rel-wpt", MAC_SLAVES, envs.build_mac),
-    DynamicServoBuilder("windows", WINDOWS_SLAVES, envs.build_windows),
+    DynamicServoBuilder("windows-dev", WINDOWS_SLAVES, envs.build_windows),
     DynamicServoBuilder("windows-nightly", WINDOWS_SLAVES, envs.build_windows),
     # The below builders are not dynamic but rather have hard-coded factories
     util.BuilderConfig(

--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -77,7 +77,7 @@ arm64:
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
-windows:
+windows-dev:
   - ./mach build --dev
   - ./mach test-unit
 

--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -76,3 +76,12 @@ arm64:
   - ./mach build --rel --target=aarch64-unknown-linux-gnu
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
+
+windows:
+  - ./mach build --dev
+  - ./mach test-unit
+
+windows-nightly:
+  - ./mach build --release
+  - ./mach package --release
+  - ./etc/ci/upload_nightly.sh windows


### PR DESCRIPTION
I'm not sure if this is the right approaches, but i try.

For process kill i used ```powershell kill```, which works from bash and cmd, but needs admin privileges like any other process kill command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/426)
<!-- Reviewable:end -->
