### PR TITLE
Add ./mach build-stable to linux-dev builder.

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -35,6 +35,7 @@ linux-dev:
   - ./mach test-unit
   - ./mach build-cef
   - ./mach build-geckolib
+  - ./mach build-stable --dev
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
   - bash ./etc/ci/check_no_unwrap.sh


### PR DESCRIPTION
This is the second and last PR related to this issue in servo: https://github.com/servo/servo/issues/11806

This PR added the ./mach build-stable sub-command: https://github.com/servo/servo/pull/11945

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/427)
<!-- Reviewable:end -->
