### PR TITLE
Vagrantfile - resiliently parse env variable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,8 @@
 require 'yaml'
 
 def extract_id(env)
-  id = env.split.map do |env_var|
+  env = env.kind_of?(Array) ? env : env.split
+  id = env.map do |env_var|
     env_var[/^SALT_NODE_ID=(?<node_id>.+)$/, "node_id"]
   end.compact
   id[0]


### PR DESCRIPTION
env seems to be an array for me which means it cant have ".split" called on it. Here is an example:

```
SALT_NODE_ID=servo-master1
SALT_FROM_SCRATCH=true
```

Testplan:
`vagrant up` seems to work now

cc @aneeshusa do you mind reviewing this?