### PR TITLE
Build geckolib on Windows

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -80,6 +80,7 @@ arm64:
 windows-dev:
   - ./mach build --dev
   - ./mach test-unit
+  - ./mach build-geckolib
 
 windows-nightly:
   - ./mach build --release


### PR DESCRIPTION
In servo/servo#12338, geckolib build is fixed for Windows. This pr is for adding it to Windows builder to prevent regressions on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/436)
<!-- Reviewable:end -->
