### PR TITLE
Fix Windows HOME directory to have the proper builder name

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -45,8 +45,6 @@ build_common = Environment({
 
 build_windows = build_common + Environment({
     'CARGO_HOME': '/home/Administrator/.cargo',
-    # Set home directory, to avoid adding `cd` command on every command
-    'HOME': r'C:\buildbot\slave\windows\build',
     'MSYS': 'winsymlinks=lnk',
     'MSYSTEM': 'MINGW64',
     'PATH': ';'.join([

--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -182,6 +182,10 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
         # Add bash -l before every command on Windows builders
         bash_command = ["bash", "-l"] if self.is_windows else []
         step_kwargs['command'] = bash_command + command
+        step_env += envs.Environment({
+            # Set home directory, to avoid adding `cd` command on every command
+            'HOME': r'C:\buildbot\slave\{}\build'.format(self.builder_name),
+            })
 
         step_class = steps.ShellCommand
         args = iter(command)


### PR DESCRIPTION
The change from the builder name of `windows` to `windows-dev` means that many commands were being executed in the incorrect directory. This should fix that!

r? @edunham @aneeshusa 

cc @Ms2ger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/441)
<!-- Reviewable:end -->
