### PR TITLE
Windows changes to make the HOME env var work

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -124,8 +124,8 @@ secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 [repo.servo.buildbot]
 url = "http://build.servo.org"
 secret = "{{ pillar["homu"]["buildbot-secret"] }}"
-builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows"]
-try_builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows"]
+builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+try_builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 


### PR DESCRIPTION
There are two big changes here:

1) Make setting the `HOME` env var work properly, filling in the builder name
2) Just allow exceptions to fail to load buildbot and log normally. Right now, the `print` is being eaten by something, so it's super hard to debug failures with dynamic steps.

r? @edunham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/442)
<!-- Reviewable:end -->
