### PR TITLE
Disable checking Android build results temporarily

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -125,8 +125,8 @@ secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 [repo.servo.buildbot]
 url = "http://build.servo.org"
 secret = "{{ pillar["homu"]["buildbot-secret"] }}"
-builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
-try_builders = ["linux-dev", "linux-rel", "android", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+try_builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 


### PR DESCRIPTION
r? @edunham @aneeshusa @metajack 

I'd like to temporarily disable checking the results of Android builds.

There are two big PRs - an SM upgrade and the move to building on win32 with MSVC that are interdependent. Unfortunately, the SM upgrade also moves to a new Android c++ stdlib, which requires sweeping changes across our submodule builds that partially conflict with MSVC.

The easiest way to sequence this (imo) is to land these two PRs with their interdependencies and then I'll pick up the Android pieces immediately after they're in.

I'm still allowing Android to build on buildbot so that we get verification as I fix pieces that they're being correctly resolved.

cc @vvuk @Ms2ger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/450)
<!-- Reviewable:end -->
