### PR TITLE
Check Travis build status via GitHub instead of Travis hooks

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -147,8 +147,8 @@ try_users = {{ try }}
 [repo.{{ repo[1] }}.github]
 secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 
-[repo.{{ repo[1] }}.travis]
-token = "{{ pillar["homu"]["travis-ci-token"] }}"
+[repo.{{ repo[1] }}.status.travis]
+context = 'continuous-integration/travis-ci/push'
 
 {% endfor %}
 


### PR DESCRIPTION
r? @Manishearth 

Fixes https://github.com/servo/servo/issues/12739

cc: @metajack @edunham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/454)
<!-- Reviewable:end -->
