### PR TITLE
Add fake GitHub homebrew token

### DIFF
--- a/.travis/minion
+++ b/.travis/minion
@@ -1,3 +1,3 @@
 master: localhost  # Used to test the salt-master
-state_output: terse
+state_output: mixed
 state_tabular: True

--- a/.travis/test_pillars/buildbot/master.sls
+++ b/.travis/test_pillars/buildbot/master.sls
@@ -4,6 +4,7 @@ buildbot:
     'http-pass': 'TEST_BUILDBOT_HTTP_PASS'
     'change-pass': 'TEST_BUILDBOT_CHANGE_PASS'
     'gh-doc-token': 'TEST_BUILDBOT_GH_DOC_TOKEN'
+    'gh-homebrew-token': 'TEST_BUILDBOT_GH_HOMEBREW_TOKEN'
     'gh-hook-secret': 'TEST_BUILDBOT_GH_HOOK_SECRET'
     'gh-status-token': 'TEST_BUILDBOT_GH_STATUS_TOKEN'
     'homu-secret': 'TEST_BUILDBOT_HOMU_SECRET'


### PR DESCRIPTION
Fixes the buildbot master file.recurse failures we've been seeing recently.
Also updates the highstate output to increase the SNR.
See commit messages for details.

Follow-up to #460. This failure was missed because we were experiencing pip failures at the time, causing Travis bustage, and the PR was merged by hand without noticing the additional failures on Travis.

r? @larsbergstrom @edunham 

cc @paulrouget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/467)
<!-- Reviewable:end -->
