### PR TITLE
Fix buildbot step description for shell commands

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -141,10 +141,9 @@ class DynamicServoFactory(ServoFactory):
                 step_desc += [arg]
 
         if step_class != steps.ShellCommand:
+            step_kwargs['description'] = "running"
+            step_kwargs['descriptionDone'] = "ran"
             step_kwargs['descriptionSuffix'] = " ".join(step_desc)
-
-        step_kwargs['description'] = "running"
-        step_kwargs['descriptionDone'] = "ran"
 
         step_kwargs['env'] = step_env
         return step_class(**step_kwargs)
@@ -267,10 +266,9 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
                 step_desc += [arg]
 
         if step_class != steps.ShellCommand:
+            step_kwargs['description'] = "running"
+            step_kwargs['descriptionDone'] = "ran"
             step_kwargs['descriptionSuffix'] = " ".join(step_desc)
-
-        step_kwargs['description'] = "running"
-        step_kwargs['descriptionDone'] = "ran"
 
         step_kwargs['env'] = step_env
         return step_class(**step_kwargs)


### PR DESCRIPTION
This should fix description for shell commands where after https://github.com/servo/saltfs/pull/438 shows only "ran", instead of command.
r? @aneeshusa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/472)
<!-- Reviewable:end -->
