### PR TITLE
[RFC] Add failed build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,3 +70,8 @@ script: .travis/dispatch.sh
 
 notifications:
   webhooks: http://build.servo.org:54856/travis
+  email:
+    recipients:
+      - github-saltfs@servo.org
+    on_success: never
+    on_failure: always


### PR DESCRIPTION
Configure Travis to send emails whenver there is a failed build.
Use an email alias (github-saltfs@servo.org) to ensure all interested
parties can receive emails, instead of just the author and committer.
Per the docs (https://docs.travis-ci.com/user/notifications/), emails
are only sent for branches (e.g. master/nightly/auto).
This is meant for notifications on failed nightly builds, so always
notify on failures but avoid notifying on success.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/485)

<!-- Reviewable:end -->
