### PR TITLE
Fix homebrew analytics directory for brew 1.0

### DIFF
--- a/osx/init.sls
+++ b/osx/init.sls
@@ -22,4 +22,4 @@ disable-homebrew-analytics:
   git.config:
     - name: 'homebrew.analyticsdisabled'
     - value: 'true'
-    - repo: /usr/local
+    - repo: /usr/local/Homebrew


### PR DESCRIPTION
r? @aneeshusa @edunham 

Homebrew in version 1.0 has moved their git repository to `/usr/local/Homebrew` to avoid the various problems with Apple fooling around with `/usr/local`. See https://github.com/Homebrew/install/pull/60

Note that I *believe* we could also set `HOMEBREW_DISABLE_ANALYTICS=1`, but there's a risk that any `brew` command not done with that set would still perform analytics reporting.

This bug is currently preventing us from landing other saltfs changes. See https://github.com/servo/saltfs/pull/484

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/486)
<!-- Reviewable:end -->
