### PR TITLE
Another Windows builder. Split up linux-rel.

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -11,7 +11,7 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 LINUX_SLAVES = ["servo-linux1", "servo-linux2", "servo-linux3"]
 MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
 CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
-WINDOWS_SLAVES = ["servo-windows1"]
+WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in xrange(1, 3)]
 
 
 c = BuildmasterConfig = {}
@@ -68,7 +68,8 @@ c['schedulers'].append(schedulers.AnyBranchScheduler(
         "arm64",
         "linux-dev",
         "linux-dev-yaml",
-        "linux-rel",
+        "linux-rel-css",
+        "linux-rel-wpt",
         "mac-dev-unit",
         "mac-rel-css",
         "mac-rel-wpt1",
@@ -93,7 +94,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
         "linux-dev",
         "linux-dev-yaml",
         "linux-nightly",
-        "linux-rel",
+        "linux-rel-css",
+        "linux-rel-wpt",
         "linux-rel-intermittent",
         "mac-dev-unit",
         "mac-nightly",
@@ -172,7 +174,9 @@ c['builders'] = [
     DynamicServoBuilder("arm64", CROSS_SLAVES, envs.build_arm64),
     DynamicServoBuilder("linux-dev", LINUX_SLAVES, envs.build_linux),
     DynamicServoBuilder("linux-nightly", LINUX_SLAVES, envs.build_linux),
-    DynamicServoBuilder("linux-rel", LINUX_SLAVES,
+    DynamicServoBuilder("linux-rel-css", LINUX_SLAVES,
+                        envs.build_linux_rel_debug_assert),
+    DynamicServoBuilder("linux-rel-wpt", LINUX_SLAVES,
                         envs.build_linux_rel_debug_assert),
     DynamicServoBuilder("linux-rel-intermittent", LINUX_SLAVES,
                         envs.build_linux),

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -8,7 +8,7 @@ from passwords import SLAVE_PASSWORD, CHANGE_PASSWORD
 from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
-LINUX_SLAVES = ["servo-linux1", "servo-linux2", "servo-linux3"]
+LINUX_SLAVES = ["servo-linux{}".format(i) for i in xrange(1, 7)]
 MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
 CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
 WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in xrange(1, 3)]

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -8,10 +8,10 @@ from passwords import SLAVE_PASSWORD, CHANGE_PASSWORD
 from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
-LINUX_SLAVES = ["servo-linux{}".format(i) for i in xrange(1, 7)]
+LINUX_SLAVES = ["servo-linux{}".format(i) for i in range(1, 7)]
 MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
-CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in xrange(1, 3)]
-WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in xrange(1, 3)]
+CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in range(1, 3)]
+WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in range(1, 3)]
 
 
 c = BuildmasterConfig = {}

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -10,7 +10,7 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 LINUX_SLAVES = ["servo-linux{}".format(i) for i in xrange(1, 7)]
 MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
-CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
+CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in xrange(1, 3)]
 WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in xrange(1, 3)]
 
 

--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -54,11 +54,14 @@ linux-dev:
   - bash ./etc/ci/manifest_changed.sh
   - bash ./etc/ci/check_no_unwrap.sh
 
-linux-rel:
+linux-rel-wpt:
   - ./mach build --release
   - ./mach test-wpt-failure
   - ./mach test-wpt --release --processes 24 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
+
+linux-rel-css:
+  - ./mach build --release
   - ./mach test-css --release --processes 16 --log-raw test-css.log --log-errorsummary css-errorsummary.log
   - ./mach build-cef --release
   - ./mach build-geckolib --release

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -129,8 +129,8 @@ secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 [repo.servo.buildbot]
 url = "http://build.servo.org"
 secret = "{{ pillar["homu"]["buildbot-secret"] }}"
-builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "arm32", "arm64", "windows-dev"]
-try_builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+builders = ["linux-dev", "linux-rel-css", "linux-rel-wpt", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+try_builders = ["linux-dev", "linux-rel-css", "linux-rel-wpt", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "arm32", "arm64", "windows-dev"]
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 


### PR DESCRIPTION
r? @aneeshusa @edunham 

Adding a Windows builder in preparation for more WIndows stuff later (and, in general, more capacity with all the `try` builds going on). Splitting out linux-rel into css and wpt because the total linux-rel build is nearly an hour.

Not the long pole (that's mac-rel-wpt), but fixing that one involves testing of the `--fragment` argument to the WPT test runner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/494)
<!-- Reviewable:end -->
