### PR TITLE
Temporarily disable servo-mac1 builder

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -9,7 +9,7 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
 LINUX_SLAVES = ["servo-linux1", "servo-linux2", "servo-linux3"]
-MAC_SLAVES = ["servo-mac1", "servo-mac2", "servo-mac3", "servo-macpro1"]
+MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-macpro1"]
 CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
 WINDOWS_SLAVES = ["servo-windows1"]
 


### PR DESCRIPTION
The upgrade to Salt 2016.3 broke Salt highstate on the macs, so I've
been using servo-mac1 to investigate as it was already on the fritz.
However, it seems that it started returning results to Buildbot, failing
all builds, so it was turned off. Temporarily remove it from the builder
list to ensure it doesn't interfere with the (rapidly growing) queue
while I use it to investigate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/495)
<!-- Reviewable:end -->
