### PR TITLE
Split the macOS WPT into two chunks an add another builder

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -9,7 +9,7 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
 LINUX_SLAVES = ["servo-linux1", "servo-linux2", "servo-linux3"]
-MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-macpro1"]
+MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
 CROSS_SLAVES = ["servo-linux-cross1", "servo-linux-cross2"]
 WINDOWS_SLAVES = ["servo-windows1"]
 
@@ -71,7 +71,8 @@ c['schedulers'].append(schedulers.AnyBranchScheduler(
         "linux-rel",
         "mac-dev-unit",
         "mac-rel-css",
-        "mac-rel-wpt",
+        "mac-rel-wpt1",
+        "mac-rel-wpt2",
         "windows-dev",
     ],
     change_filter=util.ChangeFilter(filter_fn=servo_auto_try_filter),
@@ -98,7 +99,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
         "mac-nightly",
         "mac-rel-css",
         "mac-rel-intermittent",
-        "mac-rel-wpt",
+        "mac-rel-wpt1",
+        "mac-rel-wpt2",
         "windows-dev",
         "windows-nightly",
     ],
@@ -178,7 +180,8 @@ c['builders'] = [
     DynamicServoBuilder("mac-nightly", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("mac-rel-css", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("mac-rel-intermittent", MAC_SLAVES, envs.build_mac),
-    DynamicServoBuilder("mac-rel-wpt", MAC_SLAVES, envs.build_mac),
+    DynamicServoBuilder("mac-rel-wpt1", MAC_SLAVES, envs.build_mac),
+    DynamicServoBuilder("mac-rel-wpt2", MAC_SLAVES, envs.build_mac),
     DynamicServoBuilder("windows-dev", WINDOWS_SLAVES, envs.build_windows),
     DynamicServoBuilder("windows-nightly", WINDOWS_SLAVES, envs.build_windows),
     # The below builders are not dynamic but rather have hard-coded factories

--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -1,11 +1,15 @@
-mac-rel-wpt:
+mac-rel-wpt1:
   - ./mach build --release
   - ./mach test-wpt-failure
-  - ./mach test-wpt --release --processes 8 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log
+  - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 8 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
   - ./mach build-cef --release
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
+
+mac-rel-wpt2:
+  - ./mach build --release
+  - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log
 
 mac-dev-unit:
   - ./mach build --dev

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -129,8 +129,8 @@ secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 [repo.servo.buildbot]
 url = "http://build.servo.org"
 secret = "{{ pillar["homu"]["buildbot-secret"] }}"
-builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
-try_builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "arm32", "arm64", "windows-dev"]
+try_builders = ["linux-dev", "linux-rel", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "arm32", "arm64", "windows-dev"]
 username = "{{ pillar["homu"]["buildbot-http-user"] }}"
 password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 


### PR DESCRIPTION
r? @aneeshusa 

cc @jgraham 

This splits the WPT tests into two chunks, using the default strategy. The first chunk is significantly smaller than the second (900s vs 1800s, locally), so I've loaded the extra tasks onto that machine. The other chunking strategy (hash) is not yet fully supported in WPT, but we might want to go to it after this to provide more even partitioning.

I've also added a name for another mac mini builder and will probably bring such a machine online shortly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/497)
<!-- Reviewable:end -->
