### PR TITLE
Propagate default workdir for newly created steps

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -167,6 +167,7 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
 
     haltOnFailure = True
     flunkOnFailure = True
+    workdir = None
 
     def __init__(self, builder_name, environment, yaml_path, **kwargs):
         kwargs = self.setupShellMixin(kwargs)
@@ -174,6 +175,10 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
         self.builder_name = builder_name
         self.environment = environment
         self.yaml_path = yaml_path
+
+    def setDefaultWorkdir(self, workdir):
+        buildstep.BuildStep.setDefaultWorkdir(self, workdir)
+        self.workdir = workdir
 
     @defer.inlineCallbacks
     def run(self):


### PR DESCRIPTION
The StepsYAMLParsingStep is statically in the step list of the factory,
so when starting a build Buildbot will call `setDefaultWorkdir` on each
step. We need to save this value and propagate it to the steps we
create on the fly to ensure they also receive a workdir value.

Another step towards #316.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/502)
<!-- Reviewable:end -->
