### PR TITLE
`mach package` treated as a steps.Compile

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -106,6 +106,8 @@ class DynamicServoFactory(ServoFactory):
                 step_desc = [mach_arg]
                 if re.match('build(-.*)?', mach_arg):
                     step_class = steps.Compile
+                elif re.match('package', mach_arg):
+                    step_class = steps.Compile
                 elif re.match('test-.*', mach_arg):
                     step_class = steps.Test
 
@@ -250,6 +252,8 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
                 mach_arg = next(args)
                 step_desc = [mach_arg]
                 if re.match('build(-.*)?', mach_arg):
+                    step_class = steps.Compile
+                elif re.match('package', mach_arg):
                     step_class = steps.Compile
                 elif re.match('test-.*', mach_arg):
                     step_class = steps.Test


### PR DESCRIPTION
@aneeshusa: as per issue #372, both `make_step` now have a heuristic for checking that the argument passed to mach (`mach_arg`) is `'package'` and assigns `step_class = steps.Compile`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/503)
<!-- Reviewable:end -->
