### PR TITLE
Add release stylo unit tests

### DIFF
--- a/buildbot/master/files/config/steps.yml
+++ b/buildbot/master/files/config/steps.yml
@@ -65,6 +65,7 @@ linux-rel-css:
   - ./mach test-css --release --processes 16 --log-raw test-css.log --log-errorsummary css-errorsummary.log
   - ./mach build-cef --release
   - ./mach build-geckolib --release
+  - ./mach test-stylo --release
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 


### PR DESCRIPTION
https://github.com/servo/servo/pull/13700 moved some important binding layout tests to test-stylo (they used to be run by the regen script).

Currently test-stylo is only run in debug mode. This runs it in release mode as well.

Since linux-rel-css already contains a `./mach build-geckolib --release`, and `test-stylo` just needs a rebuild of style and geckolib (which takes half a minute), this shouldn't cause much of an issue.

However, linux-rel-css is one of our slowest builders. Perhaps both `build-geckolib --release` and `test-stylo --release` should be put in linux-dev instead?


r? @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/508)
<!-- Reviewable:end -->
