### PR TITLE
Fix steps reading on Windows

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -57,8 +57,9 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
     def run(self):
         self.is_windows = re.match('windows.*', self.builder_name) is not None
         try:
+            show_cmd = "cat" if not self.is_windows else "type"
             cmd = yield self.makeRemoteShellCommand(
-                command=["cat", "./{}".format(self.yaml_path)],
+                command=[show_cmd, "./{}".format(self.yaml_path)],
                 collectStdout=True
             )
             yield self.runCommand(cmd)


### PR DESCRIPTION
`cat` is not available, so use `type` which does the same thing.

r? @larsbergstrom 
I spent about ~10 seconds searching for this, but it looks like it'll work...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/514)
<!-- Reviewable:end -->
