### PR TITLE
Add windows-dev-yaml test builder

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -188,7 +188,7 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
         try:
             show_cmd = "cat" if not self.is_windows else "type"
             cmd = yield self.makeRemoteShellCommand(
-                command=[show_cmd, "./{}".format(self.yaml_path)],
+                command=[show_cmd, "{}".format(self.yaml_path)],
                 collectStdout=True
             )
             yield self.runCommand(cmd)

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -75,6 +75,7 @@ c['schedulers'].append(schedulers.AnyBranchScheduler(
         "mac-rel-wpt1",
         "mac-rel-wpt2",
         "windows-dev",
+        "windows-dev-yaml",
     ],
     change_filter=util.ChangeFilter(filter_fn=servo_auto_try_filter),
 ))
@@ -104,6 +105,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
         "mac-rel-wpt1",
         "mac-rel-wpt2",
         "windows-dev",
+        "windows-dev-yaml",
         "windows-nightly",
     ],
 ))
@@ -195,8 +197,12 @@ c['builders'] = [
         factory=factories.doc,
     ),
     # Testing the In Tree YAML build
-    DynamicServoYAMLBuilder("linux-dev-yaml", LINUX_SLAVES,
-                            envs.build_linux)
+    DynamicServoYAMLBuilder(
+        "linux-dev-yaml", LINUX_SLAVES, envs.build_linux
+    ),
+    DynamicServoYAMLBuilder(
+        "windows-dev-yaml", WINDOWS_SLAVES, envs.build_windows
+    ),
 ]
 
 


### PR DESCRIPTION
This will allow ironing out the kinks with dynamic steps on Windows builders.
Also includes a potential fix for the latest issue.

r? @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/516)
<!-- Reviewable:end -->
