### PR TITLE
add http-observatory tests

### DIFF
--- a/tests/sls/nginx/docker-compose-extra-observatory.yml
+++ b/tests/sls/nginx/docker-compose-extra-observatory.yml
@@ -25,7 +25,7 @@ services:
       build.servo.org.test: 172.101.0.1
   observatory-cli:
     image: jarondl/observatory-cli
-    links: 
+    links:
       - website
     environment:
       HTTPOBS_API_URL: http://website:57001/api/v1/

--- a/tests/sls/nginx/docker-compose-extra-observatory.yml
+++ b/tests/sls/nginx/docker-compose-extra-observatory.yml
@@ -1,0 +1,31 @@
+version: '2'
+
+# This file adds a static network configuration to compose.
+# That is because we need to know the host's ip, and it can change
+# every time you run compose. (see GH: docker/docker#1143).
+#
+# We also add the hostname to the services that use it, and setup the
+# observatory-cli container
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.101.0.0/16
+          ip_range: 172.101.0.0/24
+          gateway: 172.101.0.1
+
+
+services:
+  scanner:
+    extra_hosts:
+      build.servo.org.test: 172.101.0.1
+  website:
+    extra_hosts:
+      build.servo.org.test: 172.101.0.1
+  observatory-cli:
+    image: jarondl/observatory-cli
+    links: 
+      - website
+    environment:
+      HTTPOBS_API_URL: http://website:57001/api/v1/

--- a/tests/sls/nginx/httpobs.py
+++ b/tests/sls/nginx/httpobs.py
@@ -1,0 +1,48 @@
+import subprocess
+import time
+import os.path
+from tempfile import TemporaryDirectory
+
+from tests.util import Failure, Success
+
+MINSCORE = '65'
+
+
+def run():
+    # set up
+    with TemporaryDirectory() as http_obs:
+        http_obs_dir = os.path.join(http_obs, 'http-observatory')
+        # getting the observatory code
+        subprocess.run(['git', 'clone', '--depth', '1',
+                        'https://github.com/mozilla/http-observatory.git',
+                        http_obs_dir], check=True)
+
+        docker_compose = [
+            'docker-compose', '-f',
+            os.path.join(http_obs_dir, 'docker-compose.yml'),
+            '-f', 'tests/sls/nginx/docker-compose-extra-observatory.yml']
+        # getting the observatory up
+        subprocess.run(docker_compose + ['up', '-d'], check=True)
+
+        # sleep for 5 seconds, to increase the chance everything is really up
+        print('sleep 5 seconds while composing up')
+        time.sleep(5)
+
+        # check our site to get the report nicely formatted in stdout
+        subprocess.run(docker_compose +
+                       ['run', 'observatory-cli', 'build.servo.org.test',
+                        '--format', 'report', '--rescan',
+                        '--attempts', '20'], check=True)
+
+        # check our site a second time with a minimal score
+        # to decide Fail / Pass
+        report = subprocess.run(docker_compose + ['run', 'observatory-cli',
+                                                  'build.servo.org.test',
+                                                  '--min-score', MINSCORE],
+                                stderr=subprocess.DEVNULL,
+                                stdout=subprocess.DEVNULL)
+        if report.returncode == 0:
+            return Success('Http Observatory score more than %s' % MINSCORE)
+        else:
+            return Failure('Http Observatory score less than %s' % MINSCORE,
+                           '')


### PR DESCRIPTION
Add a locally (docker) deployed http-observatory test.
It requires a minimum score of 65, and also prints the test results to
stdout.
Helps with #473.
Will fail on travis for two reasons: 
1. #505 - buildbot does not run automatically on travis right now
2. #511 - the security headers were not merged yet, so our score is 0

The code is not so elegant, running external code from within Python, but it works.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/518)

<!-- Reviewable:end -->
