### PR TITLE
Update to a newer version of the Android NDK

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -84,7 +84,6 @@ build_linux_rel_debug_assert = build_linux + Environment({
 build_android = build_linux + Environment({
     'ANDROID_NDK': '{{ common.servo_home }}/android/ndk/current/',
     'ANDROID_SDK': '{{ common.servo_home }}/android/sdk/current/',
-    'ANDROID_TOOLCHAIN': '{{ common.servo_home }}/android/toolchain/current/',
     'PATH': ':'.join([
         '/usr/local/sbin',
         '/usr/local/bin',
@@ -93,7 +92,6 @@ build_android = build_linux + Environment({
         '/sbin',
         '/bin',
         '{{ common.servo_home }}/android/sdk/current/platform-tools',
-        '{{ common.servo_home }}/android/toolchain/current/bin',
     ]),
 })
 

--- a/servo-build-dependencies/android.sls
+++ b/servo-build-dependencies/android.sls
@@ -28,6 +28,7 @@ android-dependencies:
       - lib32z1
       - libstdc++6
       - libgl1-mesa-dev
+      - unzip
     - refresh: True
   pip.installed:
     - pkgs:
@@ -79,25 +80,18 @@ android-sdk-current:
 
 
 android-ndk:
-  file.managed:
-    - name: {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}-linux-x86_64.bin
-    - source: https://dl.google.com/android/ndk/android-ndk-{{ android.ndk.version }}-linux-x86_64.bin
+  archive.extracted:
+    - name: {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}
+    - source: https://dl.google.com/android/repository/android-ndk-{{ android.ndk.version }}-linux-x86_64.zip
     - source_hash: sha512={{ android.ndk.sha512 }}
+    - archive_format: zip
+      # Workaround for https://github.com/saltstack/salt/pull/36552
+    - archive_user: servo
     - user: servo
     - group: servo
-    - mode: 744
-    - dir_mode: 755
-    - makedirs: True
+    - if_missing: {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}
     - require:
       - user: servo
-  cmd.run:
-      # Need to filter log output to avoid hitting log limits on Travis CI
-    - name: '{{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}-linux-x86_64.bin | grep -v Extracting'
-    - runas: servo
-    - cwd: {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}
-    - creates: {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}
-    - require:
-      - file: android-ndk
 
 android-ndk-current:
   file.symlink:
@@ -106,5 +100,4 @@ android-ndk-current:
     - user: servo
     - group: servo
     - require:
-      - cmd: android-ndk
-
+      - android-ndk

--- a/servo-build-dependencies/android.sls
+++ b/servo-build-dependencies/android.sls
@@ -99,15 +99,6 @@ android-ndk:
     - require:
       - file: android-ndk
 
-android-toolchain:
-  cmd.run:
-    - name: bash {{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}/build/tools/make-standalone-toolchain.sh --platform=android-{{ android.platform }} --toolchain=arm-linux-androideabi-4.8 --install-dir='{{ common.servo_home }}/android/toolchain/{{ android.ndk.version }}/android-toolchain' --ndk-dir='{{ common.servo_home }}/android/ndk/{{ android.ndk.version }}/android-ndk-{{ android.ndk.version }}'
-    - runas: servo
-    - creates: {{ common.servo_home }}/android/toolchain/{{ android.ndk.version }}/android-toolchain
-    - require:
-      - cmd: android-ndk
-
-# Toolchain depends on NDK so update the symlinks together
 android-ndk-current:
   file.symlink:
     - name: {{ common.servo_home }}/android/ndk/current
@@ -116,14 +107,4 @@ android-ndk-current:
     - group: servo
     - require:
       - cmd: android-ndk
-      - cmd: android-toolchain
 
-android-toolchain-current:
-  file.symlink:
-    - name: {{ common.servo_home }}/android/toolchain/current
-    - target: {{ common.servo_home }}/android/toolchain/{{ android.ndk.version }}/android-toolchain
-    - user: servo
-    - group: servo
-    - require:
-      - cmd: android-ndk
-      - cmd: android-toolchain

--- a/servo-build-dependencies/map.jinja
+++ b/servo-build-dependencies/map.jinja
@@ -7,8 +7,8 @@
       'sha512': '96fb71d78a8c2833afeba6df617edcd6cc4e37ecd0c3bec38c39e78204ed3c2bd54b138a56086bf5ccd95e372e3c36e72c1550c13df8232ec19537da93049284'
     },
     'ndk': {
-      'version': 'r10e',
-      'sha512': '8948c7bd1621e32dce554d5cd1268ffda2e9c5e6b2dda5b8cf0266ea60aa2dd6fddf8d290683fc1ef0b69d66c898226c7f52cc567dbb14352b4191ac19dfb371'
+      'version': 'r12b',
+      'sha512': '2d85b476436ca50896e4b7c5d0f15547fd14a6ebec7e0081022b28f791709af78ea5ebddcdf4722b5e94daeac288d509bd5f240b0280167edef8e199da3d0501'
     }
   }
 %}


### PR DESCRIPTION
r? @aneeshusa 

Comments from @mmatyas welcome :-)

There are two parts to this change.
1) Update the NDK. Google has both changed the DL URL format and removed the excutable bit in favor of a normal zipfile.
2) We no longer use the android standalone toolchain stuff, as that is not compatible with the LLVM libc++ that SpiderMonkey now requires us to use on Android.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/529)

<!-- Reviewable:end -->
