### PR TITLE
Re provide homebrew upload token

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -195,6 +195,11 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
                         r'C:\Program Files\Amazon\cfn-bootstrap',
                     ])
 
+            # Set token for homebrew repository
+            elif arg == './etc/ci/update_brew.sh':
+                step_kwargs['logEnviron'] = False
+                step_env += envs.update_brew
+
             else:
                 step_desc += [arg]
 

--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -25,8 +25,10 @@ class ServoFactory(util.BuildFactory):
         Prefer using DynamicServoFactory to using this class directly.
         """
         all_steps = [
-            steps.Git(repourl=SERVO_REPO,
-                      mode="full", method="fresh", retryFetch=True),
+            steps.Git(
+                repourl=SERVO_REPO,
+                mode="full", method="fresh", retryFetch=True
+            ),
         ] + build_steps
         # util.BuildFactory is an old-style class so we cannot use super()
         # but must hardcode the superclass here
@@ -76,8 +78,9 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
             else:
                 builder_steps = yaml.safe_load(cmd.stdout)
                 commands = builder_steps[self.builder_name]
-                dynamic_steps = [self.make_step(command)
-                                 for command in commands]
+                dynamic_steps = [
+                    self.make_step(command) for command in commands
+                ]
         except Exception as e:  # Bad step configuration, fail build
             # Capture the exception and re-raise with a friendly message
             raise Exception("Bad step configuration for {}: {}".format(


### PR DESCRIPTION
 This was added to the previous `make_step` implementation,
but apparently was not copied over to this implementation,
causing our Homebrew uploads to fail for the last 4 days.
Re-add this logic.

Note that because adding the token to the environment and telling
Buildbot not to log the environment are configured together,
the token was not leaked during this time.

r? @larsbergstrom 
Fixes #532.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/533)
<!-- Reviewable:end -->
