### PR TITLE
homu: Add ability to add per-repo reviewers.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -15,55 +15,154 @@ port = 54856
 secret = "{{ pillar["homu"]["web-secret"] }}"
 
 {% set travis_repos = [
-    ('servo', 'angle'),
-    ('servo', 'app_units'),
-    ('servo', 'cgl-rs'),
-    ('servo', 'cocoa-rs'),
-    ('servo', 'core-foundation-rs'),
-    ('servo', 'core-graphics-rs'),
-    ('servo', 'core-text-rs'),
-    ('servo', 'devices'),
-    ('servo', 'euclid'),
-    ('servo', 'fontsan'),
-    ('servo', 'futf'),
-    ('servo', 'gaol'),
-    ('servo', 'gleam'),
-    ('servo', 'glutin'),
-    ('servo', 'heapsize'),
-    ('servo', 'highfive'),
-    ('servo', 'homu'),
-    ('servo', 'html5ever'),
-    ('servo', 'io-surface-rs'),
-    ('servo', 'ipc-channel'),
-    ('servo', 'libexpat'),
-    ('servo', 'libfontconfig'),
-    ('servo', 'libfreetype2'),
-    ('servo', 'mozjs'),
-    ('servo', 'osmesa-src'),
-    ('servo', 'rust-azure'),
-    ('servo', 'rust-bindgen'),
-    ('servo', 'rust-cssparser'),
-    ('servo', 'rust-fnv'),
-    ('servo', 'rust-fontconfig'),
-    ('servo', 'rust-freetype'),
-    ('servo', 'rust-glx'),
-    ('servo', 'rust-harfbuzz'),
-    ('servo', 'rust-layers'),
-    ('servo', 'rust-mozjs'),
-    ('servo', 'rust-png'),
-    ('servo', 'rust-selectors'),
-    ('servo', 'rust-smallvec'),
-    ('servo', 'rust-stb-image'),
-    ('servo', 'rust-url'),
-    ('servo', 'saltfs'),
-    ('servo', 'servo-starters'),
-    ('servo', 'skia'),
-    ('servo', 'string-cache'),
-    ('servo', 'tendril'),
-    ('servo', 'unicode-bidi'),
-    ('servo', 'unicode-script'),
-    ('servo', 'webrender'),
-    ('servo', 'webrender_traits'),
+    {
+        "name": "angle"
+    },
+    {
+        "name": "app_units"
+    },
+    {
+        "name": "cgl-rs"
+    },
+    {
+        "name": "cocoa-rs"
+    },
+    {
+        "name": "core-foundation-rs"
+    },
+    {
+        "name": "core-graphics-rs"
+    },
+    {
+        "name": "core-text-rs"
+    },
+    {
+        "name": "devices"
+    },
+    {
+        "name": "euclid"
+    },
+    {
+        "name": "fontsan"
+    },
+    {
+        "name": "futf"
+    },
+    {
+        "name": "gaol"
+    },
+    {
+        "name": "gleam"
+    },
+    {
+        "name": "glutin"
+    },
+    {
+        "name": "heapsize"
+    },
+    {
+        "name": "highfive"
+    },
+    {
+        "name": "homu"
+    },
+    {
+        "name": "html5ever"
+    },
+    {
+        "name": "io-surface-rs"
+    },
+    {
+        "name": "ipc-channel"
+    },
+    {
+        "name": "libexpat"
+    },
+    {
+        "name": "libfontconfig"
+    },
+    {
+        "name": "libfreetype2"
+    },
+    {
+        "name": "mozjs"
+    },
+    {
+        "name": "osmesa-src"
+    },
+    {
+        "name": "rust-azure"
+    },
+    {
+        "name": "rust-bindgen",
+        "extra_reviewers": [ "fitzgen" ],
+    },
+    {
+        "name": "rust-cssparser"
+    },
+    {
+        "name": "rust-fnv"
+    },
+    {
+        "name": "rust-fontconfig"
+    },
+    {
+        "name": "rust-freetype"
+    },
+    {
+        "name": "rust-glx"
+    },
+    {
+        "name": "rust-harfbuzz"
+    },
+    {
+        "name": "rust-layers"
+    },
+    {
+        "name": "rust-mozjs"
+    },
+    {
+        "name": "rust-png"
+    },
+    {
+        "name": "rust-selectors"
+    },
+    {
+        "name": "rust-smallvec"
+    },
+    {
+        "name": "rust-stb-image"
+    },
+    {
+        "name": "rust-url"
+    },
+    {
+        "name": "saltfs"
+    },
+    {
+        "name": "servo-starters"
+    },
+    {
+        "name": "skia"
+    },
+    {
+        "name": "string-cache"
+    },
+    {
+        "name": "tendril"
+    },
+    {
+        "name": "unicode-bidi"
+    },
+    {
+        "name": "unicode-script"
+    },
+    {
+        "name": "webrender"
+    },
+    {
+        "name": "webrender_traits"
+    },
 ] %}
 
 {% set reviewers = [
@@ -123,7 +222,7 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
 [repo.servo]
 owner = "servo"
 name = "servo"
-reviewers = {{ reviewers + operators}}
+reviewers = {{ reviewers + operators }}
 try_users = {{ try }}
 
 [repo.servo.github]
@@ -145,16 +244,16 @@ password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 
 {% for repo in travis_repos %}
 
-[repo.{{ repo[1] }}]
-owner = "{{ repo[0] }}"
-name = "{{ repo[1] }}"
-reviewers = {{ reviewers + operators }}
+[repo.{{ repo["name"] }}]
+owner = "{{ repo.get("owner", "servo") }}"
+name = "{{ repo["name"] }}"
+reviewers = {{ reviewers + operators + repo.get("extra_reviewers", []) }}
 try_users = {{ try }}
 
-[repo.{{ repo[1] }}.github]
+[repo.{{ repo["name"] }}.github]
 secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 
-[repo.{{ repo[1] }}.status.travis]
+[repo.{{ repo["name"] }}.status.travis]
 context = 'continuous-integration/travis-ci/push'
 
 {% endfor %}


### PR DESCRIPTION
I've been thinking about adding @fitzgen to the reviewers in servo/rust-bindgen.

I think he can perfectly get access to full reviewer privileges, but there are
also a few contributors that I've been considering giving access to, and those
don't need full Servo reviewer access.

This adds a way to add per-repo reviewers to the travis repos, something I guess
it's also useful for rust-url, where there are more people with write
permissions.

The way this is organized makes easier to add "out-of-the-org" repos too.

r? @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/536)
<!-- Reviewable:end -->
