### PR TITLE
pin python 2.7.9 to make SNI work

### DIFF
--- a/buildbot/slave/files/config/buildbot.tac
+++ b/buildbot/slave/files/config/buildbot.tac
@@ -1,4 +1,3 @@
-
 import os
 
 from buildslave.bot import BuildSlave

--- a/common/init.sls
+++ b/common/init.sls
@@ -39,6 +39,18 @@ virtualenv:
     - require:
       - pkg: pip
 
+# Prereqs for making SNI work, slaves run tests where they load an https page
+{% if grains['os'] == 'Ubuntu' %}
+https-sni-deps:
+  pip.installed:
+    - pkgs:
+      - pyopenssl
+      - ndg-httpsclient
+      - pyasn1
+    - require:
+      - pkg: pip
+{% endif %}
+
 servo:
   user.present:
     - fullname: Tom Servo


### PR DESCRIPTION
see http://stackoverflow.com/questions/18578439/using-requests-with-tls-doesnt-give-sni-support/18579484#18579484 for more info but really it's the Right Thing to make sure all the builders are on the same python version anyways

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/542)
<!-- Reviewable:end -->
