### PR TITLE
Add persistent intermittent tracker

### DIFF
--- a/common/init.sls
+++ b/common/init.sls
@@ -8,6 +8,11 @@ python2:
     - refresh: True
     {% endif %}
 
+python3:
+  pkg.installed:
+    - pkgs:
+      - python3
+
 {% if grains['os'] == 'Ubuntu' %}
 python2-dev:
   pkg.installed:

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -1,10 +1,5 @@
 {% from tpldir ~ '/map.jinja' import homu %}
 
-python3:
-  pkg.installed:
-    - pkgs:
-      - python3
-
 homu-debugging-packages:
   pkg.installed:
     - pkgs:

--- a/intermittent-tracker/files/config.json
+++ b/intermittent-tracker/files/config.json
@@ -1,0 +1,1 @@
+{"token": "{{ pillar["homu"]["gh-access-token"] }}"}

--- a/intermittent-tracker/files/tracker.conf
+++ b/intermittent-tracker/files/tracker.conf
@@ -1,0 +1,11 @@
+exec /home/servo/intermittent-tracker/_venv/bin/intermittent_tracker
+
+setuid servo
+setgid servo
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [016]
+
+env HOME=/home/servo
+
+chdir /home/servo/intermittent-tracker

--- a/intermittent-tracker/init.sls
+++ b/intermittent-tracker/init.sls
@@ -1,0 +1,48 @@
+{% from tpldir ~ '/map.jinja' import tracker %}
+
+tracker-debugging-packages:
+  pip.installed:
+    - pkgs:
+      - github3.py == 1.0.0a4
+
+intermittent-tracker:
+  virtualenv.managed:
+    - name: /home/servo/intermittent-tracker/_venv
+    - venv_bin: virtualenv-3.5
+    - python: python3
+    - system_site_packages: False
+    - require:
+      - pkg: python3
+      - pip: virtualenv
+  pip.installed:
+    - pkgs:
+      - git+https://github.com/Manishearth/intermittent-tracker@{{ tracker.rev }}
+    - bin_env: /home/servo/intermittent-tracker/_venv
+    - require:
+      - virtualenv: intermittent-tracker
+  service.running:
+    - enable: True
+    - name: tracker
+    - require:
+      - pip: intermittent-tracker
+    - watch:
+      - file: /home/servo/intermittent-tracker/config.json
+      - file: /etc/init/tracker.conf
+
+/home/servo/intermittent-tracker/config.json:
+  file.managed:
+    - source: salt://{{ tpldir }}/files/config.json
+    - template: jinja
+    - user: servo
+    - group: servo
+    - mode: 644
+
+/etc/init/tracker.conf:
+  file.managed:
+    - source: salt://{{ tpldir }}/files/tracker.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: intermittent-tracker
+      - file: /home/servo/intermittent-tracker/config.json

--- a/intermittent-tracker/map.jinja
+++ b/intermittent-tracker/map.jinja
@@ -1,0 +1,5 @@
+{%
+  set tracker = {
+    'rev': 'ab89a189f6829af30cd34ae83cebfa2601b9f238'
+  }
+%}

--- a/nginx/default
+++ b/nginx/default
@@ -10,5 +10,8 @@ server {
   location /homu/ {
     proxy_pass http://localhost:54856/;
   }
+  location /intermittent-tracker/ {
+    proxy_pass http://localhost:5000/;
+  }
 }
 

--- a/top.sls
+++ b/top.sls
@@ -34,5 +34,6 @@ base:
     - git
     - buildbot.master
     - homu
+    - intermittent-tracker
     - nginx
     - salt.master


### PR DESCRIPTION
(fixes #543)

r? @larsbergstrom

cc @aneeshusa @jdm

Needs https://github.com/servo/intermittent-tracker/pull/1

This is basically a copy of the homu setup, just tweaked to work with this.

This does not contain a job to set up intermittents.json on startup; but this can be added later.

Works running locally in vagrant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/544)
<!-- Reviewable:end -->
