### PR TITLE
Use non-broken hash for Salt fileserver cache checking

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -11,6 +11,7 @@
             },
             'gitfs_remotes': [ 'https://github.com/servo/saltfs.git' ],
             'gitfs_env_whitelist': [ 'base' ],
+            'hash_type': 'sha384',
             'pillar_roots': {
               'base': [ '/srv/pillar' ]
             }


### PR DESCRIPTION
The default is md5, so upgrade to a better hash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/546)
<!-- Reviewable:end -->
