### PR TITLE
Enable unlimited Salt job logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ infrastructure. See [the tutorials](https://docs.saltstack.com/en/2016.3/topics/
 
 ## Contributing
 
-There are guides available on [the servo wiki](https://github.com/servo/servo/wiki/Buildbot-administration).
+There are guides available on [the servo wiki](https://github.com/servo/servo/wiki/Buildbot-administration),
+as well as some documention in-tree in the `docs` folder.
 If you see a way that these configurations could be improved, or try to set up
 your own instance and run into trouble, file [an issue](https://github.com/servo/saltfs/issues/new)!
 

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -1,0 +1,40 @@
+# Notes on Salt
+
+## Looking up previous runs
+
+Salt keeps track of the results of each `job` it performs,
+where a single `job` may be running a single `state.highstate` on one minion,
+looking up a `job` on a minion, running `test.ping` on a minion, etc.
+We have configured Salt's built-in job cache to never remove entries,
+so it is possible to look up the results of old jobs from the Salt master.
+
+You can use the Salt `jobs` runner to interact with the jobs system.
+To list jobs, use `list_jobs`:
+
+```console
+root@servo-master1$ salt-run jobs.list_jobs
+```
+
+Because Salt keeps track of all jobs, not just highstates, most likely
+you will want to restrict to list of jobs to just highstates:
+
+```console
+root@servo-master1$ salt-run jobs.list_jobs search_function='state.highstate'
+```
+
+You can also filter by minion, start and end date; see the docs for more info.
+
+Each job has an associated `jid`, or Job Id. Once you have a jid,
+you can look up more details about that job:
+
+```console
+root@servo-master1$ salt-run jobs.print_job <jid>
+```
+
+To get just the return data for a highstate with the highstate formatting, use:
+
+```console
+root@servo-master1$ salt-run jobs.lookup_jid <jid> --out=highstate
+```
+
+See [the Salt docs](https://docs.saltstack.com/en/2016.3/ref/runners/all/salt.runners.jobs.html#module-salt.runners.jobs) for futher documentation.

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -12,6 +12,7 @@
             'gitfs_remotes': [ 'https://github.com/servo/saltfs.git' ],
             'gitfs_env_whitelist': [ 'base' ],
             'hash_type': 'sha384',
+            'keep_jobs': 0,
             'pillar_roots': {
               'base': [ '/srv/pillar' ]
             }


### PR DESCRIPTION
Add some docs in tree as well about this feature,
to avoid forgetting to update the wiki when the PR lands.

This is a potential (partial?) fix for #437, with two caveats:
- I'm not sure of a way to "tag" a highstate deployment with the revision/PR being deployed; we'll still need to keep track of that manually
- The `keep_jobs` config option is a number of hours (the default is 24), so we can set it a concrete number instead of 0 for unlimited if you'd like.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/547)
<!-- Reviewable:end -->
