### PR TITLE
Update rev for intermittent-tracker

### DIFF
--- a/intermittent-tracker/map.jinja
+++ b/intermittent-tracker/map.jinja
@@ -1,5 +1,5 @@
 {%
   set tracker = {
-    'rev': 'ab89a189f6829af30cd34ae83cebfa2601b9f238'
+    'rev': 'e5b2858f128e2f67b6ae5fdc9e4170619156ca2e'
   }
 %}


### PR DESCRIPTION
The new revision appears to be a rebased version of the previous revision,
which is now a dangling commit on GitHub and thus not included with
clone, and is currently causing Salt runs/builds to fail,
blocking landing other PRs via Travis.

This is a temporary fix until the PR for these commits (https://github.com/servo/intermittent-tracker/pull/1) is merged.

r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/548)
<!-- Reviewable:end -->
