### PR TITLE
[Proposal] Give @kvark reviewer privileges.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -179,6 +179,7 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
     "jgraham",
     "KiChjang",
     "kmcallister",
+    "kvark",
     "larsbergstrom",
     "Manishearth",
     "mbrubeck",


### PR DESCRIPTION
kvark has make several important contributions to webrender,
both as a reviewer and committer. He also has significant
Rust experience previously as the author of gfx-rs.

Some examples of recent reviews:

https://github.com/servo/webrender/pull/546
https://github.com/servo/webrender/pull/523
https://github.com/servo/webrender/pull/561
https://github.com/servo/webrender/pull/554

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/551)
<!-- Reviewable:end -->
