### PR TITLE
Make CheckRevisionStep Twisted-compatible

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -41,7 +41,7 @@ class CheckRevisionStep(buildstep.BuildStep):
                 )
             )
 
-        defer.returnValue(SUCCESS)
+        yield defer.returnValue(SUCCESS)
 
 
 class ServoFactory(util.BuildFactory):


### PR DESCRIPTION
The inlineCallbacks decorator requires that the function it wraps
(here, the run() method of CheckRevisionStep) is a generator, so that
is is able to suspend execution to require it to insert callbacks.

Make run() into a generator by yielding the Deferred return value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/554)
<!-- Reviewable:end -->
