### PR TITLE
Invalidate Salt cache on Travis between runs

### DIFF
--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -58,12 +58,13 @@ else
         run_salt 'old'
         set -o errexit
 
-        git checkout "${TRAVIS_COMMIT}"
-        run_salt 'upgrade'
-
-        # Invalidate the Salt cache
+        travis_fold_start "salt.invalidate_cache" 'Invalidating the Salt cache'
         rm -rf /var/cache/salt/minion/files/base/*
         salt_call 'saltutil.sync_all'
+        travis_fold_end "salt.invalidate_cache"
+
+        git checkout "${TRAVIS_COMMIT}"
+        run_salt 'upgrade'
     fi
 
     # Only run tests against the new configuration


### PR DESCRIPTION
The code previously invalidated the Salt cache after completing both
runs, which was never the intent. Move it to the right place.

(Since it was clearing the cache after both runs it's questionable
whether or not this code is actually useful, but it can't hurt to keep.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/564)
<!-- Reviewable:end -->
