### PR TITLE
Upload MSVC Nightlies from MSYS environment

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -218,7 +218,7 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
             ):
                 step_kwargs['logEnviron'] = False
                 step_env += envs.upload_nightly
-                if self.is_win_gnu:
+                if self.is_windows:
                     # s3cmd on Windows GNU does not work in MINGW
                     step_env['MSYSTEM'] = 'MSYS'
                     step_env['PATH'] = ';'.join([


### PR DESCRIPTION
This should fix uploading MSVC nightlies, this also need updated step in `buildbot_steps.yml` to prefix `bash -l`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/572)
<!-- Reviewable:end -->
