### PR TITLE
Enable Homu for download.servo.org

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -40,6 +40,9 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
         "name": "devices"
     },
     {
+        "name": "download.servo.org"
+    },
+    {
         "name": "euclid"
     },
     {


### PR DESCRIPTION
r? @metajack @larsbergstrom 
This also needs:

- [x] Homu webhook configured
- [x] Travis enabled for the repo
- [ ] `.travis.yml` file for the repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/574)
<!-- Reviewable:end -->
