### PR TITLE
Quote repo names to ensure valid TOML

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -252,16 +252,16 @@ password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 
 {% for repo in travis_repos %}
 
-[repo.{{ repo["name"] }}]
+[repo."{{ repo["name"] }}"]
 owner = "{{ repo.get("owner", "servo") }}"
 name = "{{ repo["name"] }}"
 reviewers = {{ reviewers + operators + repo.get("extra_reviewers", []) }}
 try_users = {{ try }}
 
-[repo.{{ repo["name"] }}.github]
+[repo."{{ repo["name"] }}".github]
 secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 
-[repo.{{ repo["name"] }}.status.travis]
+[repo."{{ repo["name"] }}".status.travis]
 context = 'continuous-integration/travis-ci/push'
 
 {% endfor %}


### PR DESCRIPTION
Otherwise repos like `download.servo.org`
which contain dots in their name are not parsed correctly;
using quotes ensures the repo name is parsed as a single string.

Discovered while trying to merge https://github.com/servo/download.servo.org/pull/16.
I have little TOML experience, so I'm not sure if this actually works or will break our `cfg.toml` entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/580)
<!-- Reviewable:end -->
