### PR TITLE
notify travis status in servo-bots channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,3 +80,5 @@ script: .travis/dispatch.sh
 
 notifications:
   webhooks: http://build.servo.org:54856/travis
+  irc: "irc.mozilla.org#servo-bots"
+


### PR DESCRIPTION
this is the other half of fixing https://github.com/servo/saltfs/issues/376 

i have already turned on nightly builds via travis's experimental cron feature

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/598)
<!-- Reviewable:end -->
