### PR TITLE
Try pinning to a Twisted version that worked

### DIFF
--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -11,6 +11,7 @@ buildbot-master:
       - txgithub == 15.0.0
       - boto == 2.38.0
       - pyyaml == 3.11
+      - twisted == 16.6.0
     - require:
       - pkg: pip
   service.running:


### PR DESCRIPTION
So Twisted 17.1.0 came out right when
https://travis-ci.org/servo/saltfs/jobs/201390958 failure started happening,
as Aneesh noted in https://github.com/servo/saltfs/issues/601

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/604)
<!-- Reviewable:end -->
