### PR TITLE
Clean up Homu cfg.toml Jinja usage

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -25,7 +25,9 @@ secret = "{{ secrets['web-secret'] }}"
     "core-text-rs": {},
     "devices": {},
     "download.servo.org": {},
-    "euclid": {},
+    "euclid": {
+        "extra_reviewers": [ "nical" ],
+    },
     "fontsan": {},
     "futf": {},
     "gaol": {},
@@ -70,7 +72,9 @@ secret = "{{ secrets['web-secret'] }}"
     "tendril": {},
     "unicode-bidi": {},
     "unicode-script": {},
-    "webrender": {},
+    "webrender": {
+        "extra_reviewers": [ "nical" ],
+    },
     "webrender_traits": {},
 } %}
 
@@ -99,7 +103,6 @@ secret = "{{ secrets['web-secret'] }}"
     "michaelwu",
     "mrobinson",
     "Ms2ger",
-    "nical",
     "notriddle",
     "nox",
     "pcwalton",

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -151,8 +151,32 @@ secret = "{{ secrets['gh-webhook-secret'] }}"
 [repo.servo.buildbot]
 url = "http://build.servo.org"
 secret = "{{ secrets["buildbot-secret"] }}"
-builders = ["linux-dev", "linux-rel-css", "linux-rel-wpt", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "android", "arm32", "arm64", "windows-msvc-dev"]
-try_builders = ["linux-dev", "linux-rel-css", "linux-rel-wpt", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "android", "arm32", "arm64", "windows-msvc-dev"]
+builders = [
+    "linux-dev",
+    "linux-rel-css",
+    "linux-rel-wpt",
+    "mac-dev-unit",
+    "mac-rel-wpt1",
+    "mac-rel-wpt2",
+    "mac-rel-css",
+    "android",
+    "arm32",
+    "arm64",
+    "windows-msvc-dev",
+]
+try_builders = [
+    "linux-dev",
+    "linux-rel-css",
+    "linux-rel-wpt",
+    "mac-dev-unit",
+    "mac-rel-wpt1",
+    "mac-rel-wpt2",
+    "mac-rel-css",
+    "android",
+    "arm32",
+    "arm64",
+    "windows-msvc-dev",
+]
 username = "{{ secrets["buildbot-http-user"] }}"
 password = "{{ secrets["buildbot-http-pass"] }}"
 

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -15,166 +15,64 @@ host = "0.0.0.0"
 port = 54856
 secret = "{{ pillar["homu"]["web-secret"] }}"
 
-{% set travis_repos = [
-    {
-        "name": "angle"
-    },
-    {
-        "name": "app_units"
-    },
-    {
-        "name": "cgl-rs"
-    },
-    {
-        "name": "cocoa-rs"
-    },
-    {
-        "name": "core-foundation-rs"
-    },
-    {
-        "name": "core-graphics-rs"
-    },
-    {
-        "name": "core-text-rs"
-    },
-    {
-        "name": "devices"
-    },
-    {
-        "name": "download.servo.org"
-    },
-    {
-        "name": "euclid"
-    },
-    {
-        "name": "fontsan"
-    },
-    {
-        "name": "futf"
-    },
-    {
-        "name": "gaol"
-    },
-    {
-        "name": "gleam"
-    },
-    {
-        "name": "glutin"
-    },
-    {
-        "name": "heapsize"
-    },
-    {
-        "name": "highfive"
-    },
-    {
-        "name": "homu"
-    },
-    {
-        "name": "html5ever"
-    },
-    {
-        "name": "io-surface-rs"
-    },
-    {
-        "name": "ipc-channel",
+{% set travis_repos = {
+    "angle": {},
+    "app_units": {},
+    "cgl-rs": {},
+    "cocoa-rs": {},
+    "core-foundation-rs": {},
+    "core-graphics-rs": {},
+    "core-text-rs": {},
+    "devices": {},
+    "download.servo.org": {},
+    "euclid": {},
+    "fontsan": {},
+    "futf": {},
+    "gaol": {},
+    "gleam": {},
+    "glutin": {},
+    "heapsize": {},
+    "highfive": {},
+    "homu": {},
+    "html5ever": {},
+    "io-surface-rs": {},
+    "ipc-channel": {
         "extra_reviewers": [ "antrik" ],
     },
-    {
-        "name": "libexpat"
-    },
-    {
-        "name": "libfontconfig"
-    },
-    {
-        "name": "libfreetype2"
-    },
-    {
-        "name": "mozjs"
-    },
-    {
-        "name": "osmesa-src"
-    },
-    {
-        "name": "rust-azure"
-    },
-    {
-        "name": "rust-bindgen",
+    "libexpat": {},
+    "libfontconfig": {},
+    "libfreetype2": {},
+    "mozjs": {},
+    "osmesa-src": {},
+    "rust-azure": {},
+    "rust-bindgen": {
         "extra_reviewers": [ "fitzgen" ],
     },
-    {
-        "name": "rust-cssparser"
-    },
-    {
-        "name": "rust-fnv"
-    },
-    {
-        "name": "rust-fontconfig"
-    },
-    {
-        "name": "rust-freetype"
-    },
-    {
-        "name": "rust-glx"
-    },
-    {
-        "name": "rust-harfbuzz"
-    },
-    {
-        "name": "rust-layers"
-    },
-    {
-        "name": "rust-mozjs"
-    },
-    {
-        "name": "rust-png"
-    },
-    {
-        "name": "rust-quicksort"
-    },
-    {
-        "name": "rust-selectors"
-    },
-    {
-        "name": "rust-smallvec"
-    },
-    {
-        "name": "rust-stb-image"
-    },
-    {
-        "name": "rust-url"
-    },
-    {
-        "name": "rust-websocket"
-    },
-    {
-        "name": "saltfs"
-    },
-    {
-        "name": "servo-starters"
-    },
-    {
-        "name": "skia"
-    },
-    {
-        "name": "string-cache"
-    },
-    {
-        "name": "tendril"
-    },
-    {
-        "name": "unicode-bidi"
-    },
-    {
-        "name": "unicode-script"
-    },
-    {
-        "name": "webrender"
-    },
-    {
-        "name": "webrender_traits"
-    },
-] %}
+    "rust-cssparser": {},
+    "rust-fnv": {},
+    "rust-fontconfig": {},
+    "rust-freetype": {},
+    "rust-glx": {},
+    "rust-harfbuzz": {},
+    "rust-layers": {},
+    "rust-mozjs": {},
+    "rust-png": {},
+    "rust-quicksort": {},
+    "rust-selectors": {},
+    "rust-smallvec": {},
+    "rust-stb-image": {},
+    "rust-url": {},
+    "rust-websocket": {},
+    "saltfs": {},
+    "servo-starters": {},
+    "skia": {},
+    "string-cache": {},
+    "tendril": {},
+    "unicode-bidi": {},
+    "unicode-script": {},
+    "webrender": {},
+    "webrender_traits": {},
+} %}
 
 {% set reviewers = [
     "aneeshusa",
@@ -264,18 +162,18 @@ password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
 
 # Standard per-repo configs (generated)
 
-{% for repo in travis_repos %}
+{% for name, repo in travis_repos.items() %}
 
-[repo."{{ repo["name"] }}"]
+[repo."{{ name }}"]
 owner = "{{ repo.get("owner", "servo") }}"
-name = "{{ repo["name"] }}"
+name = "{{ name }}"
 reviewers = {{ reviewers + operators + repo.get("extra_reviewers", []) }}
 try_users = {{ try }}
 
-[repo."{{ repo["name"] }}".github]
+[repo."{{ name }}".github]
 secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
 
-[repo."{{ repo["name"] }}".status.travis]
+[repo."{{ name }}".status.travis]
 context = 'continuous-integration/travis-ci/push'
 
 {% endfor %}

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -4,16 +4,16 @@
 # under <https://github.com/settings/applications>.
 
 # A GitHub personal access token
-access_token = "{{ pillar["homu"]["gh-access-token"] }}"
+access_token = "{{ secrets['gh-access-token'] }}"
 
 # A GitHub oauth application for this instance of homu:
-app_client_id = "{{ pillar["homu"]["app-client-id"] }}"
-app_client_secret = "{{ pillar["homu"]["app-client-secret"] }}"
+app_client_id = "{{ secrets['app-client-id'] }}"
+app_client_secret = "{{ secrets['app-client-secret'] }}"
 
 [web]
 host = "0.0.0.0"
 port = 54856
-secret = "{{ pillar["homu"]["web-secret"] }}"
+secret = "{{ secrets['web-secret'] }}"
 
 {% set travis_repos = {
     "angle": {},
@@ -146,15 +146,15 @@ reviewers = {{ reviewers + operators }}
 try_users = {{ try }}
 
 [repo.servo.github]
-secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
+secret = "{{ secrets['gh-webhook-secret'] }}"
 
 [repo.servo.buildbot]
 url = "http://build.servo.org"
-secret = "{{ pillar["homu"]["buildbot-secret"] }}"
+secret = "{{ secrets["buildbot-secret"] }}"
 builders = ["linux-dev", "linux-rel-css", "linux-rel-wpt", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "android", "arm32", "arm64", "windows-msvc-dev"]
 try_builders = ["linux-dev", "linux-rel-css", "linux-rel-wpt", "mac-dev-unit", "mac-rel-wpt1", "mac-rel-wpt2", "mac-rel-css", "android", "arm32", "arm64", "windows-msvc-dev"]
-username = "{{ pillar["homu"]["buildbot-http-user"] }}"
-password = "{{ pillar["homu"]["buildbot-http-pass"] }}"
+username = "{{ secrets["buildbot-http-user"] }}"
+password = "{{ secrets["buildbot-http-pass"] }}"
 
 # Disabled due to performance and instability
 #[repo.servo.status.appveyor]
@@ -171,7 +171,7 @@ reviewers = {{ reviewers + operators + repo.get("extra_reviewers", []) }}
 try_users = {{ try }}
 
 [repo."{{ name }}".github]
-secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
+secret = "{{ secrets['gh-webhook-secret'] }}"
 
 [repo."{{ name }}".status.travis]
 context = 'continuous-integration/travis-ci/push'
@@ -206,7 +206,7 @@ reviewers = {{ reviewers + operators }}
 try_users = {{ try }}
 
 [repo.dwrote-rs.github]
-secret = "{{ pillar["homu"]["gh-webhook-secret"] }}"
+secret = "{{ secrets['gh-webhook-secret'] }}"
 
 [repo.dwrote-rs.status.appveyor]
 context = 'continuous-integration/appveyor/branch'

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -52,6 +52,7 @@ homu:
     - template: jinja
     - context:
         db: {{ homu.db }}
+        secrets: {{ pillar['homu'] }}
 
 /etc/init/homu.conf:
   file.managed:


### PR DESCRIPTION
Finally got around to https://github.com/servo/saltfs/pull/536#issuecomment-260547879, plus a few extras.

This should yield no change in the deployed Homu `cfg.toml`; that is, check the `servo-master1` Travis build running with `SALT_FROM_SCRATCH=false` to ensure that the state for `cfg.toml` reports no changes on the second run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/605)
<!-- Reviewable:end -->
