### PR TITLE
Change steps.Git(… method="fresh") to method="clean"

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -57,7 +57,7 @@ class ServoFactory(util.BuildFactory):
         all_steps = [
             steps.Git(
                 repourl=SERVO_REPO,
-                mode="full", method="fresh", retryFetch=True
+                mode="full", method="clean", retryFetch=True
             ),
             CheckRevisionStep(),
         ] + build_steps


### PR DESCRIPTION
http://docs.buildbot.net/latest/manual/cfg-buildsteps.html#git

This will keep the `target` directory between builds, and hopefully reduce build times since not every build will need to recompile everything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/611)
<!-- Reviewable:end -->
