### PR TITLE
Use separate homu user for Homu-related states

### DIFF
--- a/homu/init.sls
+++ b/homu/init.sls
@@ -9,8 +9,13 @@ homu-debugging-packages:
       - sqlite3
 
 homu:
+  user.present:
+    - fullname: Homu
+    - shell: /bin/bash
+    - home: /home/servo/homu
   virtualenv.managed:
     - name: /home/servo/homu/_venv
+    - user: homu
     - venv_bin: virtualenv-3.5
     - python: python3
     - system_site_packages: False
@@ -18,6 +23,7 @@ homu:
       - pkg: python3
       - pip: virtualenv
   pip.installed:
+    - user: homu
     - pkgs:
       - git+https://github.com/servo/homu@{{ homu.rev }}
       - toml == 0.9.1  # Please ensure this is in sync with requirements.txt
@@ -36,9 +42,9 @@ homu:
   file.managed:
     - source: salt://{{ tpldir }}/files/cfg.toml
     - template: jinja
-    - user: servo
-    - group: servo
-    - mode: 644
+    - user: homu
+    - group: homu
+    - mode: 640
 
 /etc/init/homu.conf:
   file.managed:

--- a/tests/sls/homu/config_permissions.py
+++ b/tests/sls/homu/config_permissions.py
@@ -1,0 +1,26 @@
+import os
+import pwd
+import stat
+
+from tests.util import Failure, Success
+
+
+def get_owner(filename):
+    return pwd.getpwuid(os.stat(filename).st_uid).pw_name
+
+
+def is_world_readable(filename):
+    st = os.stat(filename)
+    return bool(st.st_mode & stat.S_IROTH)
+
+
+def run():
+    for root, directories, filenames in os.walk('/home/servo/homu/'):
+        for filename in filenames:
+            full_path = os.path.join(root, filename)
+            if get_owner(full_path) != 'homu':
+                return Failure('Homu file is not owned by \'homu\' user:',
+                               full_path)
+            if is_world_readable(full_path):
+                return Failure('Homu file is world-readable:', full_path)
+    return Success('Homu files have valid permissions')


### PR DESCRIPTION
Fixes #422 

- Added 'homu' user
- Added parameters to run pip and virtualenv under 'homu' user
- Changed homu config owner and permissions to prevent it to be read by strangers :)
- Added code that tests these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/615)
<!-- Reviewable:end -->
