### PR TITLE
Add Diane and Canaltinova to reviewers

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -178,8 +178,10 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
 {% set reviewers = [
     "aneeshusa",
     "asajeffrey",
+    "avadacatavra",
     "bholley",
     "bzbarsky",
+    "canaltinova",
     "cbrewster",
     "edunham",
     "emilio",
@@ -215,8 +217,6 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
 
 {% set try = [
     "askalski",
-    "avadacatavra",
-    "canaltinova",
     "chandler",
     "cynicaldevil",
     "danlrobertson",


### PR DESCRIPTION
@avadacatavra is a Mozilla employee (she's reviewed servo/servo#15889 and servo/servo#15783, and possibly more in the future). And, @canaltinova has reviewed various PRs, have filed a number of issues for newcomers, and is a frequent contributor to servo. I think we can move both of them to reviewers list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/616)
<!-- Reviewable:end -->
