### PR TITLE
Add clang dependency required for rust-bindgen

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -33,6 +33,8 @@ servo-dependencies:
       - libosmesa6-dev
       - libssl-dev
       - llvm-3.5-dev
+      - libclang-3.5-dev
+      - clang-3.5
       - xorg-dev
       - xpra
       - xserver-xorg-input-void


### PR DESCRIPTION
This allows us to use crates which depend on rust-bindgen.

Required for https://github.com/servo/servo/pull/16059. There are more rust-bindgen based dependencies coming soon (https://crates.io/crates/gvr-sys)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/626)
<!-- Reviewable:end -->
