### PR TITLE
Set up taking a GitHub access token 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,11 @@ matrix:
       language: python
       python: 3.5
 
-script: .travis/dispatch.sh
+before_script:
+    - echo $GHTOKENLINE >> .travis/test_pillars/homu.sls
+
+script:
+    - .travis/dispatch.sh
 
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/.travis/test_pillars/homu.sls
+++ b/.travis/test_pillars/homu.sls
@@ -1,5 +1,4 @@
 homu:
-  'gh-access-token': 'TEST_HOMU_GH_ACCESS_TOKEN'
   'gh-webhook-secret': 'TEST_HOMU_GH_WEBHOOK_SECRET'
   'app-client-id': 'TEST_HOMU_APP_CLIENT_ID'
   'app-client-secret': 'TEST_HOMU_APP_CLIENT_SECRET'

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ your own instance and run into trouble, file [an issue](https://github.com/servo
 
 TravisCI is set up to test all configurations.
 
+Environment variables:
+
+With a valid GitHub access token instead of the following placeholder value,
+set the `GHTOKENLINE` env var to:
+
+```
+   'gh-access-token' : 'abc123def456'
+```
+
+The whole thing goes in the var because it's needlessly confusing to try to
+sneak the punctuation through both bash and Travis's yaml parser.
+
 ## License
 
 This repository is distributed under the terms of both the MIT license


### PR DESCRIPTION
Duct tape fix to #606. I have created a token with no special perms from my account and stuck it in the appropriate slot in the Travis UI to expose it as an env var to this repo's builds. We can change the contents of that env var through the UI at any time so it'll be easy enough to switch it to a token with different scopes, and eventually to one on Homu's account, in the process of debugging this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/627)
<!-- Reviewable:end -->
