### PR TITLE
Pin Twisted version for builders

### DIFF
--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -11,7 +11,7 @@ buildbot-master:
       - txgithub == 15.0.0
       - boto == 2.38.0
       - pyyaml == 3.11
-      - twisted == 16.6.0
+      - twisted == 16.6.0  # NOTE: keep in sync with buildbot-slave sls
     - require:
       - pkg: pip
   service.running:

--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -19,12 +19,14 @@ buildbot-master:
     # Buildbot must be restarted manually! See 'Buildbot administration' on the
     # wiki and https://github.com/servo/saltfs/issues/304.
     - require:
+      - user: servo
       - pip: buildbot-master
-      - file: {{ common.servo_home }}/buildbot/master
+      - file: ownership-{{ common.servo_home }}/buildbot/master
       - file: /etc/init/buildbot-master.conf
 
-{{ common.servo_home }}/buildbot/master:
+deploy-{{ common.servo_home }}/buildbot/master:
   file.recurse:
+    - name: {{ common.servo_home }}/buildbot/master
     - source: salt://{{ tpldir }}/files/config
     - user: servo
     - group: servo
@@ -34,6 +36,8 @@ buildbot-master:
     - context:
         common: {{ common }}
         buildbot_credentials: {{ pillar['buildbot']['credentials'] }}
+    - require:
+      - user: servo
 
 ownership-{{ common.servo_home }}/buildbot/master:
   file.directory:
@@ -43,6 +47,8 @@ ownership-{{ common.servo_home }}/buildbot/master:
     - recurse:
       - user
       - group
+    - require:
+      - file: deploy-{{ common.servo_home }}/buildbot/master
 
 /etc/init/buildbot-master.conf:
   file.managed:

--- a/buildbot/slave/init.sls
+++ b/buildbot/slave/init.sls
@@ -25,6 +25,8 @@ buildbot-slave-dependencies:
     - template: jinja
     - context:
         common: {{ common }}
+    - require:
+      - user: servo
 
 {% if grains['kernel'] == 'Darwin' %}
 
@@ -56,6 +58,8 @@ buildbot-slave-dependencies:
 buildbot-slave:
   service.running:
     - enable: True
+    - require:
+      - user: servo
     - watch:
       - pip: buildbot-slave-dependencies
       - file: {{ common.servo_home }}/buildbot/slave

--- a/buildbot/slave/init.sls
+++ b/buildbot/slave/init.sls
@@ -7,6 +7,7 @@ buildbot-slave-dependencies:
   pip.installed:
     - pkgs:
       - buildbot-slave == 0.8.12
+      - twisted == 16.6.0 # NOTE: keep in sync with buildbot-master sls
     - require:
       - pkg: pip
 
@@ -56,4 +57,5 @@ buildbot-slave:
   service.running:
     - enable: True
     - watch:
+      - pip: buildbot-slave-dependencies
       - file: {{ common.servo_home }}/buildbot/slave


### PR DESCRIPTION
I was following up on #588 and saw that a `servo-linux-cross3` machine has been provisioned, but the buildmaster doesn't know about it. Checking the logs, it appears that the buildbot-slave service doesn't start successfully, and the stack trace seems to be the same reason as https://github.com/servo/saltfs/issues/601#issuecomment-279163471, namely a version of Twisted that is too new. This PR is similar to #604, but pins the Twisted version for builders instead of the buildmaster.

I also included some more requisites.
This should fix #588 once deployed.

r? @edunham @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/630)
<!-- Reviewable:end -->
