### PR TITLE
Operator access for jryans

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -214,6 +214,7 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
 
 {% set operators = [
     "BorisChiou",
+    "jryans",
 ] %}
 
 {% set try = [
@@ -226,7 +227,6 @@ secret = "{{ pillar["homu"]["web-secret"] }}"
     "gsnedders",
     "GuillaumeGomez",
     "izgzhen",
-    "jryans",
     "magni-",
     "paulrouget",
     "stshine",


### PR DESCRIPTION
I am actively working on the Stylo project. @Manishearth suggested that I ask for operator access so that I can more easily land changes that have already been reviewed in Bugzilla.

(I am a Mozilla employee with L3 access to Gecko.)

cc @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/635)
<!-- Reviewable:end -->
