### PR TITLE
Set JAVA_HOME env var to OpenJDK 8 for Android builds

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -79,6 +79,8 @@ build_linux = build_common + Environment({
 build_android = build_linux + Environment({
     'ANDROID_NDK': '{{ common.servo_home }}/android/ndk/current/',
     'ANDROID_SDK': '{{ common.servo_home }}/android/sdk/current/',
+    # TODO(aneeshusa): Template this value for e.g. macOS builds
+    'JAVA_HOME': '/usr/lib/jvm/java-8-openjdk-amd64',
     'PATH': ':'.join([
         '/usr/local/sbin',
         '/usr/local/bin',


### PR DESCRIPTION
The new gradle builds require Java 8,
and the existing ant builds also work with Java 8.

This is easier than running many `update-alternatives` calls from Salt.
Moreover, this allows keeping Java 7 installed together with Java 8.

Needed for servo/servo#15773.
Follow-up to to #617 and #629.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/638)
<!-- Reviewable:end -->
