### PR TITLE
Make Buildbot aware of servo-linux-cross3 builder

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -10,7 +10,7 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 LINUX_SLAVES = ["servo-linux{}".format(i) for i in range(1, 7)]
 MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
-CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in range(1, 3)]
+CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in range(1, 4)]
 WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in range(1, 3)]
 
 


### PR DESCRIPTION
The Buildbot master is reporting an `invalid login from unknown user 'servo-linux-cross3'`.
Make it aware of the new cross builder.

Fixes #588.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/643)
<!-- Reviewable:end -->
