### PR TITLE
Adding gitSha as a step kwarg and env var

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -230,6 +230,11 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
             else:
                 step_desc += [arg]
 
+        # Add Git SHA for tracking testing failures
+        if step_class == steps.Test:
+            step_env['GIT_SHA'] = self.getProperty('got_revision')
+            step_kwargs['gitSha'] = self.getProperty('got_revision')
+
         if step_class != steps.ShellCommand:
             step_kwargs['description'] = "running"
             step_kwargs['descriptionDone'] = "ran"


### PR DESCRIPTION
To be able to find the pull request for intermittent issues, we need to add the gitSha into the build steps so the PR can be queried from github. More information here: #597. In support of: https://github.com/servo/servo/wiki/Tracking-intermittent-failures-over-time-project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/648)
<!-- Reviewable:end -->
