### PR TITLE
Use Docker for testing on Travis, start on 16.04 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,23 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
+    # Salt inside Docker
+    - env:
+        - SALT_NODE_ID=servo-linux1
+        - SALT_FROM_SCRATCH=true
+          # ubuntu/14.04
+        - SALT_DOCKER_IMAGE=ubuntu@sha256:edf05697d8ea17028a69726b4b450ad48da8b29884cd640fec950c904bfb50ce
+      os: linux
+      sudo: required
+      dist: trusty
+    - env:
+        - SALT_NODE_ID=servo-linux1
+        - SALT_FROM_SCRATCH=true
+          # ubuntu/16.04
+        - SALT_DOCKER_IMAGE=ubuntu@sha256:f3a61450ae43896c4332bda5e78b453f4a93179045f20c8181043b26b5e79028
+      os: linux
+      sudo: required
+      dist: trusty
     # Not a Salt node, runs test suite instead
     - env:
         - SALT_NODE_ID=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# Python is not supported on OS X yet
-# But a system python is installed for all workers
+# Handle Python installation and dependencies ourselves
 language: cpp
 
 # NOTE: Make sure the matrix covers all node types in top.sls
@@ -14,8 +13,6 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
     - env:
         - SALT_NODE_ID=servo-mac1
         - SALT_FROM_SCRATCH=true
@@ -27,16 +24,12 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
     - env:
         - SALT_NODE_ID=servo-master1
         - SALT_FROM_SCRATCH=true
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
     # Salt from previous configuration
     - env:
         - SALT_NODE_ID=servo-linux-cross1
@@ -44,8 +37,6 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
     - env:
         - SALT_NODE_ID=servo-mac1
         - SALT_FROM_SCRATCH=false
@@ -57,24 +48,18 @@ matrix:
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
     - env:
         - SALT_NODE_ID=servo-master1
         - SALT_FROM_SCRATCH=false
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
     # Not a Salt node, runs test suite instead
     - env:
         - SALT_NODE_ID=test
       os: linux
       sudo: required
       dist: trusty
-      language: python
-      python: 3.5
 
 script: .travis/dispatch.sh
 

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -13,16 +13,16 @@ salt_call() {
         "$@"
 }
 
-travis_fold_start () {
+travis_fold_start() {
     printf "travis_fold:start:%s\n" "${1}"
     printf "%s\n" "${2}"
 }
 
-travis_fold_end () {
+travis_fold_end() {
     printf "travis_fold:end:%s\n" "${1}"
 }
 
-run_salt () {
+run_salt() {
     travis_fold_start "salt.install.$1" 'Installing and configuring Salt'
     .travis/install_salt.sh -F -c .travis -- "${TRAVIS_OS_NAME}"
     travis_fold_end "salt.install.$1"

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -40,6 +40,19 @@ run_salt() {
 }
 
 
+setup_venv() {
+    local -r VENV_DIR="/tmp/saltfs-venv3"
+    printf "Using %s at %s\n" "$(python3 --version)" "$(which python3)"
+
+    python3 -m venv "${VENV_DIR}"
+    set +o nounset
+    source "${VENV_DIR}/bin/activate"
+    set -o nounset
+    pip install wheel
+    pip install -r requirements.txt
+}
+
+
 SUDO=""
 if (( EUID != 0 )); then
     SUDO="sudo"
@@ -47,10 +60,8 @@ fi
 
 
 if [[ "${SALT_NODE_ID}" == "test" ]]; then
-    # Using .travis.yml to specify Python 3.5 to be preinstalled, just to check
-    printf "Using %s at %s\n" "$(python3 --version)" "$(which python3)"
-
     # Run test suite separately for parallelism
+    setup_venv
     ./test.py
 else
     if [ "${SALT_FROM_SCRATCH}" = "true" ]; then
@@ -75,6 +86,8 @@ else
     fi
 
     # Only run tests against the new configuration
+    setup_venv
+
     # TODO: don't hard-code this
     if [[ "${SALT_NODE_ID}" == "servo-master1" ]]; then
         ./test.py sls.buildbot.master sls.homu sls.nginx

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -7,7 +7,7 @@ set -o pipefail
 shopt -s nullglob
 
 salt_call() {
-    sudo salt-call \
+    ${SUDO} salt-call \
         --id="${SALT_NODE_ID}" \
         --local --file-root='./.' --pillar-root='./.travis/test_pillars' \
         "$@"
@@ -38,6 +38,12 @@ run_salt() {
     printf 'Running the full Salt highstate\n'
     salt_call --retcode-passthrough --log-level=warning state.highstate
 }
+
+
+SUDO=""
+if (( EUID != 0 )); then
+    SUDO="sudo"
+fi
 
 
 if [[ "${SALT_NODE_ID}" == "test" ]]; then

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -8,6 +8,7 @@ shopt -s nullglob
 
 salt_call() {
     ${SUDO} salt-call \
+        --force-color \
         --id="${SALT_NODE_ID}" \
         --local --file-root='./.' --pillar-root='./.travis/test_pillars' \
         "$@"
@@ -40,6 +41,23 @@ run_salt() {
 }
 
 
+run_inside_docker() {
+    # Reexec this script inside docker
+    # (without exporting the `SALT_DOCKER_IMAGE` environment variable
+    # to prevent recursion)
+    local -r DOCKER_SALT_ROOT="/tmp/salt"
+    docker run \
+        --env="SALT_NODE_ID=${SALT_NODE_ID}" \
+        --env="SALT_FROM_SCRATCH=${SALT_FROM_SCRATCH}" \
+        --env="TRAVIS_COMMIT=${TRAVIS_COMMIT}" \
+        --env="TRAVIS_OS_NAME=${TRAVIS_OS_NAME}" \
+        --volume="$(pwd):${DOCKER_SALT_ROOT}" \
+        --workdir="${DOCKER_SALT_ROOT}" \
+        "${SALT_DOCKER_IMAGE}" \
+        "${DOCKER_SALT_ROOT}/.travis/dispatch.sh"
+}
+
+
 setup_venv() {
     local -r VENV_DIR="/tmp/saltfs-venv3"
     printf "Using %s at %s\n" "$(python3 --version)" "$(which python3)"
@@ -63,6 +81,10 @@ if [[ "${SALT_NODE_ID}" == "test" ]]; then
     # Run test suite separately for parallelism
     setup_venv
     ./test.py
+elif [[ -n "${SALT_DOCKER_IMAGE:-}" ]]; then  # macOS bash is too old for `-v`
+    printf "Using %s\n" "$(docker -v)"
+
+    run_inside_docker "$@"
 else
     if [ "${SALT_FROM_SCRATCH}" = "true" ]; then
         run_salt 'scratch'

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -14,12 +14,12 @@ salt_call() {
 }
 
 travis_fold_start () {
-    printf "travis_fold:start:$1\n"
-    printf "$2\n"
+    printf "travis_fold:start:%s\n" "${1}"
+    printf "%s\n" "${2}"
 }
 
 travis_fold_end () {
-    printf "travis_fold:end:$1\n"
+    printf "travis_fold:end:%s\n" "${1}"
 }
 
 run_salt () {
@@ -42,7 +42,7 @@ run_salt () {
 
 if [[ "${SALT_NODE_ID}" == "test" ]]; then
     # Using .travis.yml to specify Python 3.5 to be preinstalled, just to check
-    printf "Using $(python3 --version) at $(which python3)\n"
+    printf "Using %s at %s\n" "$(python3 --version)" "$(which python3)"
 
     # Run test suite separately for parallelism
     ./test.py

--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -19,6 +19,11 @@ install_salt() {
         # Don't autostart services
         printf '#!/bin/sh\nexit 101\n' | \
             ${SUDO} install -m 755 /dev/stdin /usr/sbin/policy-rc.d
+
+        # Ensure curl is installed (is not present by default in Docker)
+        ${SUDO} apt-get -y update
+        ${SUDO} apt-get -y install --no-install-recommends ca-certificates curl
+
         curl "https://repo.saltstack.com/apt/ubuntu/${os_release}/amd64/archive/2016.3.3/SALTSTACK-GPG-KEY.pub" | \
             ${SUDO} apt-key add -
         printf \

--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -7,15 +7,24 @@ set -o pipefail
 install_salt() {
     # Ensure that pinned versions match as closely as possible
     if [[ "${OS_NAME}" == "linux" ]]; then
-        printf "%s: installing salt for Linux\n" "${0}"
-        # Use Trusty (Ubuntu 14.04) on Travis
+        local os_codename os_release
+        os_codename="$(grep 'DISTRIB_CODENAME' /etc/lsb-release | cut -f2 -d'=')"
+        declare -r os_codename
+        os_release="$(grep 'DISTRIB_RELEASE' /etc/lsb-release | cut -f2 -d'=')"
+        declare -r os_release
+        printf \
+            "%s: installing salt for Linux (%s, %s)\n" \
+            "${0}" "${os_codename}" "${os_release}"
+
         # Don't autostart services
         printf '#!/bin/sh\nexit 101\n' | \
             ${SUDO} install -m 755 /dev/stdin /usr/sbin/policy-rc.d
-        curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.3/SALTSTACK-GPG-KEY.pub | \
+        curl "https://repo.saltstack.com/apt/ubuntu/${os_release}/amd64/archive/2016.3.3/SALTSTACK-GPG-KEY.pub" | \
             ${SUDO} apt-key add -
-        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.3 trusty main\n' | \
-            ${SUDO} tee /etc/apt/sources.list.d/saltstack.list >/dev/null
+        printf \
+            'deb http://repo.saltstack.com/apt/ubuntu/%s/amd64/archive/2016.3.3 %s main\n' \
+            "${os_release}" "${os_codename}" | \
+                ${SUDO} tee /etc/apt/sources.list.d/saltstack.list >/dev/null
         ${SUDO} apt-get -y update
         # Use existing config file if it exists (if reinstalling)
         ${SUDO} apt-get -y \

--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -10,12 +10,15 @@ install_salt() {
         printf "%s: installing salt for Linux\n" "${0}"
         # Use Trusty (Ubuntu 14.04) on Travis
         # Don't autostart services
-        printf '#!/bin/sh\nexit 101\n' | sudo install -m 755 /dev/stdin /usr/sbin/policy-rc.d
-        curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.3/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.3 trusty main\n' | sudo tee /etc/apt/sources.list.d/saltstack.list >/dev/null
-        sudo apt-get -y update
+        printf '#!/bin/sh\nexit 101\n' | \
+            ${SUDO} install -m 755 /dev/stdin /usr/sbin/policy-rc.d
+        curl https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.3/SALTSTACK-GPG-KEY.pub | \
+            ${SUDO} apt-key add -
+        printf 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.3 trusty main\n' | \
+            ${SUDO} tee /etc/apt/sources.list.d/saltstack.list >/dev/null
+        ${SUDO} apt-get -y update
         # Use existing config file if it exists (if reinstalling)
-        sudo apt-get -y \
+        ${SUDO} apt-get -y \
                 -o Dpkg::Options::="--force-confold" \
                 -o Dpkg::Options::="--force-confdef" \
                 install salt-minion=2016.3.3+ds-1
@@ -43,10 +46,16 @@ configure_salt() {
     printf \
         "%s: copying Salt minion configuration from %s\n" \
         "${0}" "${TEMPORARY_CONFIG_DIR}"
-    sudo rm -rf /etc/salt
-    sudo mkdir -p /etc/salt
-    sudo cp "${FORCE_FLAG}" -- "${TEMPORARY_CONFIG_DIR}/minion" /etc/salt/minion
+    ${SUDO} rm -rf /etc/salt
+    ${SUDO} mkdir -p /etc/salt
+    ${SUDO} cp "${FORCE_FLAG}" -- \
+        "${TEMPORARY_CONFIG_DIR}/minion" /etc/salt/minion
 }
+
+SUDO=""
+if (( EUID != 0 )); then
+    SUDO="sudo"
+fi
 
 OPTIONS=$(getopt 'c:CF' "$@")
 

--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-install_salt () {
+install_salt() {
     # Ensure that pinned versions match as closely as possible
     if [[ "${OS_NAME}" == "linux" ]]; then
         printf "%s: installing salt for Linux\n" "${0}"
@@ -39,7 +39,7 @@ install_salt () {
     fi
 }
 
-configure_salt () {
+configure_salt() {
     printf \
         "%s: copying Salt minion configuration from %s\n" \
         "${0}" "${TEMPORARY_CONFIG_DIR}"

--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -7,7 +7,7 @@ set -o pipefail
 install_salt () {
     # Ensure that pinned versions match as closely as possible
     if [[ "${OS_NAME}" == "linux" ]]; then
-        printf "$0: installing salt for Linux\n"
+        printf "%s: installing salt for Linux\n" "${0}"
         # Use Trusty (Ubuntu 14.04) on Travis
         # Don't autostart services
         printf '#!/bin/sh\nexit 101\n' | sudo install -m 755 /dev/stdin /usr/sbin/policy-rc.d
@@ -20,7 +20,7 @@ install_salt () {
                 -o Dpkg::Options::="--force-confdef" \
                 install salt-minion=2016.3.3+ds-1
     elif [[ "${OS_NAME}" == "osx" ]]; then
-        printf "$0: installing salt for Mac OS X\n"
+        printf "%s: installing salt for Mac OS X\n" "${0}"
         brew update
         printf "\nhomebrew --version output:\n"
         brew --version # For debugging
@@ -34,13 +34,15 @@ install_salt () {
         # In case we had the same version previously, we need to relink
         brew link saltstack
     else
-        printf >&2 "$0: unknown operating system ${OS_NAME}\n"
+        printf >&2 "%s: unknown operating system %s\n" "${0}" "${OS_NAME}"
         exit 1
     fi
 }
 
 configure_salt () {
-    printf "$0: copying Salt minion configuration from ${TEMPORARY_CONFIG_DIR}\n"
+    printf \
+        "%s: copying Salt minion configuration from %s\n" \
+        "${0}" "${TEMPORARY_CONFIG_DIR}"
     sudo rm -rf /etc/salt
     sudo mkdir -p /etc/salt
     sudo cp "${FORCE_FLAG}" -- "${TEMPORARY_CONFIG_DIR}/minion" /etc/salt/minion
@@ -79,7 +81,7 @@ while true; do
 done
 
 if [[ "$#" -lt 1 ]]; then
-    printf >&2 "usage: $0 [-c <config_dir> [-F]] [--] os_name\n"
+    printf >&2 "usage: %s [-c <config_dir> [-F]] [--] os_name\n" "${0}"
     exit 1
 fi
 

--- a/admin/init.sls
+++ b/admin/init.sls
@@ -11,7 +11,7 @@ admin-packages:
       - mobile-shell
       {% endif %}
 
-{% if grains['os'] != 'MacOS' %}
+{% if grains['os'] != 'MacOS' and grains.get('virtual_subtype', '') != 'Docker' %}
 UTC:
     timezone.system
 {% endif %}

--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -14,6 +14,7 @@ buildbot-master:
       - twisted == 16.6.0  # NOTE: keep in sync with buildbot-slave sls
     - require:
       - pkg: pip
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
   service.running:
     - enable: True
     # Buildbot must be restarted manually! See 'Buildbot administration' on the
@@ -23,6 +24,7 @@ buildbot-master:
       - pip: buildbot-master
       - file: ownership-{{ common.servo_home }}/buildbot/master
       - file: /etc/init/buildbot-master.conf
+  {% endif %}
 
 deploy-{{ common.servo_home }}/buildbot/master:
   file.recurse:
@@ -77,12 +79,14 @@ ownership-{{ common.servo_home }}/buildbot/master:
     - context:
         common: {{ common }}
 
+{% if grains.get('virtual_subtype', '') != 'Docker' %}
 buildbot-github-listener:
   service.running:
     - enable: True
     - watch:
       - file: /usr/local/bin/github_buildbot.py
       - file: /etc/init/buildbot-github-listener.conf
+{% endif %}
 
 remove-old-build-logs:
   cron.present:

--- a/buildbot/slave/init.sls
+++ b/buildbot/slave/init.sls
@@ -50,11 +50,14 @@ buildbot-slave-dependencies:
     - template: jinja
     - context:
         common: {{ common }}
+    {% if grains.get('virtual_subtype', '') != 'Docker' %}
     - watch_in:
       - service: buildbot-slave
+    {% endif %}
 
 {% endif %}
 
+{% if grains.get('virtual_subtype', '') != 'Docker' %}
 buildbot-slave:
   service.running:
     - enable: True
@@ -63,3 +66,4 @@ buildbot-slave:
     - watch:
       - pip: buildbot-slave-dependencies
       - file: {{ common.servo_home }}/buildbot/slave
+{% endif %}

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -25,6 +25,7 @@ homu:
     - bin_env: /home/servo/homu/_venv
     - require:
       - virtualenv: homu
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
   service.running:
     - enable: True
     - require:
@@ -32,6 +33,7 @@ homu:
     - watch:
       - file: /home/servo/homu/cfg.toml
       - file: /etc/init/homu.conf
+  {% endif %}
 
 {{ salt['file.dirname'](homu.db) }}:
   file.directory:

--- a/intermittent-tracker/init.sls
+++ b/intermittent-tracker/init.sls
@@ -23,6 +23,7 @@ intermittent-tracker:
     - bin_env: /home/servo/intermittent-tracker/_venv
     - require:
       - virtualenv: intermittent-tracker
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
   service.running:
     - enable: True
     - name: tracker
@@ -31,6 +32,7 @@ intermittent-tracker:
     - watch:
       - file: /home/servo/intermittent-tracker/config.json
       - file: /etc/init/tracker.conf
+  {% endif %}
 
 /home/servo/intermittent-tracker/config.json:
   file.managed:

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -1,9 +1,12 @@
 nginx:
   pkg.installed: []
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
   service.running:
     - enable: True
     - watch:
       - pkg: nginx
+      - file: /etc/nginx/sites-available/default
+  {% endif %}
 
 /etc/nginx/sites-available/default:
   file.managed:
@@ -11,8 +14,6 @@ nginx:
     - user: root
     - group: root
     - mode: 644
-    - watch_in:
-      - service: nginx
 
 /etc/nginx/sites-enabled/default:
   file.symlink:

--- a/python/init.sls
+++ b/python/init.sls
@@ -10,6 +10,13 @@ python3:
   pkg.installed:
     - pkgs:
       - python3
+      {% if grains['os'] == 'Ubuntu' %}
+      {% if grains['osrelease'] == '14.04' %}
+      - python3.4-venv
+      {% else %}
+      - python3-venv
+      {% endif %}
+      {% endif %}
 
 {% if grains['os'] == 'Ubuntu' %}
 python2-dev:

--- a/salt/common.sls
+++ b/salt/common.sls
@@ -3,9 +3,9 @@
 {% if grains['os'] == 'Ubuntu' %}
 salt:
   pkgrepo.managed:
-    - name: 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }} trusty main'
+    - name: 'deb http://repo.saltstack.com/apt/ubuntu/{{ grains['osrelease'] }}/amd64/archive/{{ salt.version }} {{ grains['oscodename'] }} main'
     - file: /etc/apt/sources.list.d/saltstack.list
-    - key_url: https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/{{ salt.version }}/SALTSTACK-GPG-KEY.pub
+    - key_url: https://repo.saltstack.com/apt/ubuntu/{{ grains['osrelease'] }}/amd64/archive/{{ salt.version }}/SALTSTACK-GPG-KEY.pub
 
 /etc/apt/sources.list.d/saltstack.list:
   file.exists:

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -16,8 +16,10 @@ salt-master-dependencies:
     - user: root
     - group: root
     - mode: 755
+    {% if grains.get('virtual_subtype', '') != 'Docker' %}
     - require_in:
       - service: salt-master
+    {% endif %}
 
 {{ rootfs_parent_dir }}/ADMIN_README:
   file.managed:
@@ -25,8 +27,10 @@ salt-master-dependencies:
     - group: root
     - mode: 644
     - source: salt://{{ tpldir }}/files/master/ADMIN_README
+    {% if grains.get('virtual_subtype', '') != 'Docker' %}
     - require_in:
       - service: salt-master
+    {% endif %}
 {% endfor %}
 
 salt-master:
@@ -36,11 +40,13 @@ salt-master:
     - require:
       - sls: salt.common
       - pkg: salt-master-dependencies
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
   service.running:
     - enable: True
     - require:  # Updates and upgrades must be handled manually
       - file: /etc/salt/master
       - pkg: salt-master
+  {% endif %}
 
 /etc/salt/master:
   file.managed:

--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -75,10 +75,10 @@ servo-dependencies:
       - pip: virtualenv
   {% endif %}
 
-{% if grains['os'] == 'Ubuntu' and grains['oscodename'] == 'trusty' %}
+{% if grains['os'] == 'Ubuntu' %}
 multiverse:
   pkgrepo.managed:
-    - name: 'deb http://archive.ubuntu.com/ubuntu trusty multiverse'
+    - name: 'deb http://archive.ubuntu.com/ubuntu {{ grains['oscodename'] }} multiverse'
     - file: /etc/apt/sources.list.d/multiverse.list
     - require_in:
       - pkg: ttf-mscorefonts-installer

--- a/test.py
+++ b/test.py
@@ -7,8 +7,8 @@ import sys
 from tests.util import color, GREEN, RED, Failure, project_path
 
 
-def is_python_script(dir_entry):
-    return dir_entry.name.endswith('.py') and dir_entry.is_file()
+def is_python_script(path):
+    return path.endswith('.py') and os.path.isfile(path)
 
 
 def run_tests(tests):
@@ -16,10 +16,11 @@ def run_tests(tests):
 
     for test_spec in tests:
         test_dir = os.path.join(project_path(), 'tests', *test_spec.split('.'))
-
-        python_scripts = filter(is_python_script, os.scandir(test_dir))
-        tests = sorted([entry.name for entry in python_scripts])
-
+        # TODO(aneeshusa): switch back to scandir on Python 3.5+
+        tests = sorted(
+            path for path in os.listdir(test_dir)
+            if is_python_script(os.path.join(test_dir, path))
+        )
         for test in tests:
             test_mod_name = 'tests.{}.{}'.format(test_spec, test[:-3])
             test_mod = importlib.import_module(test_mod_name)
@@ -44,8 +45,8 @@ def run_tests(tests):
 
 
 def main():
-    if sys.version_info < (3, 5):  # We use features introduced in Python 3.5
-        sys.stderr.write('{}: Python 3.5 or later is needed for this script\n'
+    if sys.version_info < (3, 4):  # Only tested on 3.4 and up
+        sys.stderr.write('{}: Python 3.4 or later is needed for this script\n'
                          .format(__file__))
         return 1
 

--- a/tests/lint/flake8.py
+++ b/tests/lint/flake8.py
@@ -8,12 +8,15 @@ def run():
     paths = ['test.py', 'tests']
     paths = [os.path.join(project_path(), path) for path in paths]
     command = ['flake8'] + paths
-    ret = subprocess.run(command,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,
-                         universal_newlines=True)
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    stdout, _ = proc.communicate()
 
-    if ret.returncode == 0:
-        return Success("Tests passed flake8 lint")
-    else:
-        return Failure("Tests failed flake8 lint:", ret.stdout)
+    if proc.returncode != 0:
+        return Failure("Tests failed flake8 lint:", stdout)
+
+    return Success("Tests passed flake8 lint")

--- a/tests/lint/shebang.py
+++ b/tests/lint/shebang.py
@@ -37,8 +37,8 @@ def run():
     executables = filter(is_executable, paths())
     failures = list(filter(lambda e: not has_correct_header(e), executables))
 
-    if len(failures) == 0:
-        return Success("All executable shebangs are correct")
-    else:
+    if len(failures) != 0:
         output = '\n'.join([display_path(path) for path in failures])
         return Failure("Bad shebangs found in these files:", output)
+
+    return Success("All executable shebangs are correct")

--- a/tests/lint/trailing_whitespace.py
+++ b/tests/lint/trailing_whitespace.py
@@ -35,8 +35,8 @@ def check_whitespace(path):
 def run():
     failures = list(itertools.chain(*map(check_whitespace, paths())))
 
-    if len(failures) == 0:
-        return Success("No trailing whitespace found")
-    else:
+    if len(failures) != 0:
         output = '\n'.join([display_failure(failure) for failure in failures])
         return Failure("Trailing whitespace found on files and lines:", output)
+
+    return Success("No trailing whitespace found")

--- a/tests/sls/buildbot/master/config.py
+++ b/tests/sls/buildbot/master/config.py
@@ -4,14 +4,19 @@ from tests.util import Failure, Success
 
 
 def run():
-    command = ['sudo',  # To get access to buildbot files owned by servo
-               'buildbot', 'checkconfig', '/home/servo/buildbot/master']
-    ret = subprocess.run(command,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,
-                         universal_newlines=True)
+    command = [
+        'sudo',  # To get access to buildbot files owned by servo
+        'buildbot', 'checkconfig', '/home/servo/buildbot/master'
+    ]
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    _, stderr = proc.communicate()
 
-    if ret.returncode == 0:
-        return Success("Buildbot master config passed checkconfig")
-    else:
-        return Failure("Buildbot master config check failed:", ret.stderr)
+    if proc.returncode != 0:
+        return Failure("Buildbot master config check failed:", stderr)
+
+    return Success("Buildbot master config passed checkconfig")

--- a/tests/sls/buildbot/master/config_lint.py
+++ b/tests/sls/buildbot/master/config_lint.py
@@ -5,16 +5,24 @@ from tests.util import Failure, Success, project_path
 
 
 def run():
-    CONF_DIR = os.path.join(project_path(),
-                            'buildbot', 'master', 'files', 'config')
+    CONF_DIR = os.path.join(
+        project_path(),
+        'buildbot',
+        'master',
+        'files',
+        'config'
+    )
     # Have to specify master.cfg separately because it is not a .py file
     command = ['flake8', CONF_DIR, os.path.join(CONF_DIR, 'master.cfg')]
-    ret = subprocess.run(command,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,
-                         universal_newlines=True)
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    stdout, _ = proc.communicate()
 
-    if ret.returncode == 0:
-        return Success("Buildbot master config passed linting")
-    else:
-        return Failure("Buildbot master config lint check failed:", ret.stdout)
+    if proc.returncode != 0:
+        return Failure("Buildbot master config lint check failed:", stdout)
+
+    return Success("Buildbot master config passed linting")

--- a/tests/sls/common/timezone.py
+++ b/tests/sls/common/timezone.py
@@ -4,15 +4,15 @@ from tests.util import Failure, Success
 
 
 def run():
-    ret = subprocess.run(
+    proc = subprocess.Popen(
         ['date'],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
+        universal_newlines=True
     )
+    stdout, _ = proc.communicate()
 
-    stdout = ret.stdout.decode('utf-8')
-
-    if ret.returncode == 0 and 'UTC' in stdout:
-        return Success('Date is in UTC')
-    else:
+    if proc.returncode != 0 or 'UTC' not in stdout:
         return Failure('Date is not in UTC: ', stdout)
+
+    return Success('Date is in UTC')

--- a/tests/sls/homu/valid_builders.py
+++ b/tests/sls/homu/valid_builders.py
@@ -13,17 +13,20 @@ def run():
     # We need to invoke a new process to read the Buildbot master config
     # because Buildbot is written in python2.
     scriptpath = os.path.join(os.path.dirname(__file__), 'get_buildbot_cfg.py')
-    ret = subprocess.run(
+    proc = subprocess.Popen(
         ['/usr/bin/python2', scriptpath],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
+        universal_newlines=True
     )
-    if ret.returncode != 0:
+    stdout, stderr = proc.communicate()
+
+    if proc.returncode != 0:
         return Failure(
-            'Unable to retrieve buildbot builders:', ret.stderr
+            'Unable to retrieve buildbot builders:', stderr
         )
 
-    buildbot_builders = json.loads(ret.stdout.decode('utf-8'))['builders']
+    buildbot_builders = json.loads(stdout)['builders']
 
     failure_msg = ''
     for builder_set in ['builders', 'try_builders']:

--- a/tests/util.py
+++ b/tests/util.py
@@ -22,10 +22,10 @@ EXCLUDE_DIRS = ['.git', '.vagrant']
 
 
 def project_path():
+    abspath = os.path.realpath(os.path.join(os.getcwd(), __file__))
     # One dirname for tests dir, another for project dir
-    project_dir = os.path.dirname(os.path.dirname(__file__))
-    common = os.path.commonpath([project_dir, os.getcwd()])
-    return project_dir.replace(common, '.', 1)  # Only replace once
+    project_dir = os.path.dirname(os.path.dirname(abspath))
+    return os.path.relpath(project_dir)
 
 
 def paths():

--- a/top.sls
+++ b/top.sls
@@ -5,6 +5,7 @@ base:
     - match: compound
     - admin
     - common
+    - python
     - salt.common
 
   'os:Ubuntu':

--- a/xvfb/init.sls
+++ b/xvfb/init.sls
@@ -7,8 +7,10 @@
 
 xvfb:
   pkg.installed: []
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
   service.running:
     - enable: True
     - watch:
       - pkg: xvfb
       - file: /etc/init/xvfb.conf
+  {% endif %}


### PR DESCRIPTION
Use pinned Docker images to test our states on multiple OSes.
Currently, only `servo-linux1` is tested, on Ubuntu 14.04 and 16.04.
Also note that some states are not tested since they don't make
sense in a Docker container, mainly the `service` states;
these still need to be updated for systemd.

This starts updating the Salt states for Ubuntu 16.04 compatibility,
and thus helps with #462.

Also, make the tests run on Python 3.4, which is the default Python 3 on 14.04.
See commit messages for some other miscellaneous changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/649)
<!-- Reviewable:end -->
