### PR TITLE
Revert a51202bd953e01ce12781d93ff9726ebe7db9a59.

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -57,7 +57,7 @@ class ServoFactory(util.BuildFactory):
         all_steps = [
             steps.Git(
                 repourl=SERVO_REPO,
-                mode="full", method="clean", retryFetch=True
+                mode="full", method="fresh", retryFetch=True
             ),
             CheckRevisionStep(),
         ] + build_steps


### PR DESCRIPTION
When we don't clobber the target directory, we run into problems like https://github.com/servo/servo/issues/16602 and https://github.com/servo/servo/issues/16632 on our builders. Let's revert that until we solve it properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/651)
<!-- Reviewable:end -->
