### PR TITLE
Enable choosing build machine for force builds

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -1,4 +1,5 @@
 from buildbot.plugins import buildslave, changes, schedulers, status, util
+from buildbot.schedulers.forcesched import BuildslaveChoiceParameter
 from buildbot.status import html, status_push, web, words
 
 import environments as envs
@@ -104,6 +105,9 @@ c['schedulers'].append(schedulers.ForceScheduler(
         "windows-msvc-dev",
         "windows-msvc-nightly",
     ],
+    properties=[
+        BuildslaveChoiceParameter(),
+    ]
 ))
 c['schedulers'].append(schedulers.Nightly(
     name="Nightly",
@@ -147,6 +151,7 @@ class DynamicServoBuilder(util.BuilderConfig):
             slavenames=slavenames,
             factory=factories.DynamicServoFactory(name, environment),
             nextBuild=branch_priority,
+            canStartBuild=util.enforceChosenSlave,
         )
 
 
@@ -176,6 +181,7 @@ c['builders'] = [
         name="doc",
         slavenames=LINUX_SLAVES,
         factory=factories.doc,
+        canStartBuild=util.enforceChosenSlave,
     ),
 ]
 


### PR DESCRIPTION
This makes it easier to test if changes to a specific build machine are
working properly, e.g. the current impetus of seeing if Android-related
changes on servo-linux-cross3 are working.

Docs: https://docs.buildbot.net/0.8.12/manual/cfg-schedulers.html#buildslavechoiceparameter

Fixes: #658.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/659)
<!-- Reviewable:end -->
