### PR TITLE
Set a maximum priority for builds.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -10,6 +10,9 @@ access_token = "{{ secrets['gh-access-token'] }}"
 app_client_id = "{{ secrets['app-client-id'] }}"
 app_client_secret = "{{ secrets['app-client-secret'] }}"
 
+# Priority values above max_priority will be refused.
+max_priority = 9001
+
 [web]
 host = "0.0.0.0"
 port = 54856

--- a/homu/map.jinja
+++ b/homu/map.jinja
@@ -1,6 +1,6 @@
 {%
   set homu = {
     'db': '/var/homu/main.db',
-    'rev': '83689f0d52e64292a4eb50def23d0e9028f8aba1'
+    'rev': '62f0c9e5081e54c178fc75222e66c026a2a69f25'
   }
 %}


### PR DESCRIPTION
This should be in our configs at or before the time we deploy the changes to
get Homu to read the max priority setting.

The whole thing about having non-infinite priorities is to facilitate
sherriffing as discussed in https://github.com/servo/homu/issues/111

I pulled 9001 out of thin air because I consider it easy to memorize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/660)
<!-- Reviewable:end -->
