### PR TITLE
Revert "Make r25.2.3 the default Android SDK"

### DIFF
--- a/servo-build-dependencies/map.jinja
+++ b/servo-build-dependencies/map.jinja
@@ -1,7 +1,12 @@
 {%
   set android = {
     'sdk': {
-      'current': 'r25.2.3',
+      'current': 'r24.4.1',
+      'r24.4.1': {
+        'build_tools': '23.0.3',
+        'platform': '18',
+        'sha512': '778f43ab1d220bdc30087759862d2c0f3fa59e44122cc99666d57f37f69d46b14e4b8583e20234e23aaed4e291f5a21e607d08f69a2a9e73332889091054b8c9',
+      },
       'r25.2.3': {
         'build_tools': '25.0.2',
         'platform': '25',


### PR DESCRIPTION
This reverts commit a9e75da378eb55180681ab25d172334a607226d4.
`./mach build --android --dev` does not work with SDK 25.2.3.

SDK 25.2.3 is still available for the `./mach package step`.

This will address #661 for now to prevent all Android builds on `cross3` from failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/663)
<!-- Reviewable:end -->
