### PR TITLE
Change Wafflespeanut to wafflespeanut

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -114,7 +114,7 @@ secret = "{{ secrets['web-secret'] }}"
     "SimonSapin",
     "shinglyu",
     "upsuper",
-    "Wafflespeanut",
+    "wafflespeanut",
     "zmike",
 ] %}
 


### PR DESCRIPTION
I'd recently changed my username (so that I have the same thing throughout the web). Apparently, homu is case-insensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/673)
<!-- Reviewable:end -->
