### PR TITLE
Add 4/5 of the new macs

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -17,8 +17,7 @@ MAC_SLAVES = ["servo-mac2",
               "servo-mac6",
               "servo-mac7",
               "servo-mac8",
-              "servo-macpro1"
-             ]
+              "servo-macpro1"]
 CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in range(1, 4)]
 WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in range(1, 3)]
 

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -10,7 +10,15 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
 LINUX_SLAVES = ["servo-linux{}".format(i) for i in range(1, 7)]
-MAC_SLAVES = ["servo-mac2", "servo-mac3", "servo-mac4", "servo-macpro1"]
+MAC_SLAVES = ["servo-mac2",
+              "servo-mac3",
+              "servo-mac4",
+              "servo-mac5",
+              "servo-mac6",
+              "servo-mac7",
+              "servo-mac8",
+              "servo-macpro1"
+             ]
 CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in range(1, 4)]
 WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in range(1, 3)]
 


### PR DESCRIPTION
See https://github.com/servo/saltfs/issues/674#issuecomment-303591568. 

Test that the 4 completed new builders are actually working, and free up a bit of capacity, while I finish up with mac9. 

Also format these lines to have less icky diffs as we add and remove others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/677)
<!-- Reviewable:end -->
