### PR TITLE
Mac9 is ready

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -10,14 +10,7 @@ from passwords import HOMU_BUILDBOT_SECRET, GITHUB_STATUS_TOKEN
 
 
 LINUX_SLAVES = ["servo-linux{}".format(i) for i in range(1, 7)]
-MAC_SLAVES = ["servo-mac2",
-              "servo-mac3",
-              "servo-mac4",
-              "servo-mac5",
-              "servo-mac6",
-              "servo-mac7",
-              "servo-mac8",
-              "servo-macpro1"]
+MAC_SLAVES = ["servo-mac{}".format(i) for i in range(1, 10)]
 CROSS_SLAVES = ["servo-linux-cross{}".format(i) for i in range(1, 4)]
 WINDOWS_SLAVES = ["servo-windows{}".format(i) for i in range(1, 3)]
 


### PR DESCRIPTION
* Return mac1 to rotation
* Remove macpro1
* Add mac9
* Switch the whole thing to a nice list comprehension

This finishes up the work from https://github.com/servo/saltfs/issues/674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/679)
<!-- Reviewable:end -->
