### PR TITLE
Pin all pip dependencies for Homu

### DIFF
--- a/homu/init.sls
+++ b/homu/init.sls
@@ -20,7 +20,27 @@ homu:
   pip.installed:
     - pkgs:
       - git+https://github.com/servo/homu@{{ homu.rev }}
-      - toml == 0.9.1  # Please ensure this is in sync with requirements.txt
+      - toml==0.9.1  # Please ensure this is in sync with requirements.txt
+      # Pin all other dependencies
+      - appdirs==1.4.0
+      - bottle==0.12.13
+      - certifi==2017.4.17
+      - chardet==3.0.3
+      - github3.py==0.9.6
+      - homu==0.2.0
+      - idna==2.5
+      - Jinja2==2.9.6
+      - MarkupSafe==1.0
+      - packaging==16.8
+      - pyparsing==2.1.10
+      - requests==2.14.2
+      - retrying==1.3.3
+      - six==1.10.0
+      - toml==0.9.1
+      - uritemplate==3.0.0
+      - uritemplate.py==3.0.2
+      - urllib3==1.21.1
+      - waitress==1.0.2
     - upgrade: True
     - bin_env: /home/servo/homu/_venv
     - require:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@
 flake8 == 2.5.4
 toml == 0.9.1  # Please ensure this is in sync with homu/init.sls
 jinja2 == 2.9.6  # TODO: sync this with version used by Salt
+safety == 1.4.0
+insecure-package==0.1.0

--- a/tests/sls/homu/safety.py
+++ b/tests/sls/homu/safety.py
@@ -1,0 +1,28 @@
+import subprocess
+
+from tests.util import Failure, Success
+
+
+def run():
+    pip_proc = subprocess.Popen(
+        ['/home/servo/homu/_venv/bin/pip', 'freeze'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    safety_proc = subprocess.Popen(
+        ['safety', 'check', '--full-report', '--stdin'],
+        stdin=pip_proc.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        universal_newlines=True
+    )
+    pip_proc.stdout.close()
+    stdout, _ = safety_proc.communicate()
+
+    if safety_proc.returncode != 0:
+        return Failure(
+            'Insecure Python packages installed in Homu env:', stdout
+        )
+
+    return Success('No insecure Python packages found in Homu env')


### PR DESCRIPTION
New versions of requests that were just released removed the bundled
`cacert.pem` file, causing Homu to be unable to post comments.
Pin requests and all other Homu dependencies to avoid future problems,
now that we are using `upgrade=True` to ensure Homu gets updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/686)
<!-- Reviewable:end -->
