### PR TITLE
Support env vars in buildbot steps

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -1,5 +1,3 @@
-import copy
-
 from passwords import GITHUB_DOC_TOKEN, GITHUB_HOMEBREW_TOKEN
 from passwords import S3_UPLOAD_ACCESS_KEY_ID, S3_UPLOAD_SECRET_ACCESS_KEY
 
@@ -12,19 +10,29 @@ class Environment(dict):
 
     def __init__(self, *args, **kwargs):
         super(Environment, self).__init__(*args, **kwargs)
+        # Ensure keys and values are strings,
+        # which are immutable in Python,
+        # allowing usage of self.copy() instead of copy.deepcopy().
+        for k in self:
+            assert type(k) == str
+            assert type(self[k]) == str
+
+    def copy(self):
+        # Return an environment, not a plain dict
+        return Environment(self)
 
     def __add__(self, other):
         assert type(self) == type(other)
         combined = self.copy()
         combined.update(other)  # other takes precedence over self
-        return Environment(combined)
+        return combined
 
     def without(self, to_unset):
         """
         Return a new Environment that does not contain the environment
         variables specified in the list of strings to_unset.
         """
-        modified = copy.deepcopy(self)
+        modified = self.copy()
         assert type(to_unset) == list
         for env_var in to_unset:
             if env_var in modified:

--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import re
 
 from buildbot.plugins import steps, util
@@ -172,7 +171,7 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
 
     def make_step(self, command):
         step_kwargs = {}
-        step_env = copy.deepcopy(self.environment)
+        step_env = self.environment.copy()
 
         command = command.split(' ')
 


### PR DESCRIPTION
This makes it possible to specify environment variables for CI builds directly in `buildbot_steps.yml`, whether permanently, such as configuring LLVM assertions in servo/servo#15564, or temporarily, e.g. testing out `SCCACHE` for servo/servo#17106 before putting it into saltfs or trying out Android env vars.
This is also helpful for windows, which AFAIK doesn't have an equivalent to the `env` command.

r? @larsbergstrom @edunham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/687)
<!-- Reviewable:end -->
