### PR TITLE
Install zlib on OSX.

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -16,6 +16,7 @@ servo-dependencies:
       - openssl
       - pkg-config
       - yasm
+      - zlib
       {% elif grains['os'] == 'Ubuntu' %}
       - autoconf2.13
       - curl


### PR DESCRIPTION
Needed to update osmesa (https://github.com/servo/servo/pull/14584), which reports a not enough up-to-date zlib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/690)
<!-- Reviewable:end -->
