### PR TITLE
Install and run servo-gecko-try on its own minion

### DIFF
--- a/servo-gecko-try/files/config.json
+++ b/servo-gecko-try/files/config.json
@@ -1,0 +1,9 @@
+{
+    "servo-clone": "{{ servo-clone }}",
+    "gecko-clones": {
+        "mozilla-central": "{{ m-c-clone }}",
+        "autoland": "{{ autoland-clone }}"
+    },
+    "host": "0.0.0.0",
+    "port": 6000
+}

--- a/servo-gecko-try/files/hgrc
+++ b/servo-gecko-try/files/hgrc
@@ -1,0 +1,7 @@
+[extensions]
+mq =
+push-to-try = ~/.mozbuild/version-control-tools/hgext/push-to-try
+
+[ui]
+username = Bors <whatever@whatever.com>
+ssh = ssh -l 'borsusername@bors.com' -i '/home/servo/.ssh/id_rsa.pub'

--- a/servo-gecko-try/files/servo-gecko-try.conf
+++ b/servo-gecko-try/files/servo-gecko-try.conf
@@ -1,0 +1,12 @@
+exec /home/servo/servo-gecko-try/_venv/bin/servo-gecko-try
+
+setuid servo
+setgid servo
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [016]
+
+env HOME=/home/servo
+
+chdir /home/servo/servo-gecko-try
+

--- a/servo-gecko-try/init.sls
+++ b/servo-gecko-try/init.sls
@@ -1,0 +1,91 @@
+{% from tpldir ~ '/map.jinja' import servo-gecko-try %}
+
+user-acct:
+  user.present:
+    - name: servo-gecko-try
+    - fullname: Gecko T. Robot
+    - shell: /bin/bash
+    - home: /home/servo-gecko-try/
+
+packages:
+  pkg.installed:
+    - names:
+      - mercurial
+      - pthon-dev
+      - python-virtualenv
+
+servo-gecko-try:
+  virtualenv.managed:
+    - name: /home/servo-gecko-try/servo-gecko-try/_venv
+    - system_site_packages: False
+  pip.installed:
+    - pkgs:
+      - git+https://github.com/Manishearth/servo-gecko-try.git
+    - bin_env: /home/servo-gecko-try/servo-gecko-try/_venv
+    - upgrade: True
+    - require:
+      - virtualenv: servo-gecko-try
+  service.running:
+    - enable: True
+    - name: servo-gecko-try
+    - require:
+      - pip: servo-gecko-try
+    - watch:
+      - file: /home/servo-gecko-try/servo-gecko-try/config.json
+      - file: /etc/init/servo-gecko-try.conf
+  {% endif %}
+
+/home/servo-gecko-try/servo-gecko-try/config.json:
+  file.managed:
+    - source: salt://{{ tlpdir }}/files/config.json
+    - user: servo-gecko-try
+    - group: servo-gecko-try
+    - mode: 644
+    - template: jinja
+    - context:
+        servo-clone: {{ servo-gecko-try.servo-clone}}
+        m-c-clone: {{ servo-gecko-try.m-c }}
+        autoland-clone: {{ servo-gecko-try.autoland }}
+
+/etc/init/servo-gecko-try.conf:
+  file.managed:
+    - source: salt://{{ tpldir }}/files/servo-gecko-try.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: servo-gecko-try
+      - file: /home/servo-gecko-try/servo-gecko-try/config.json
+
+https://github.com/servo/servo/:
+  git.latest:
+    - target: {{ servo-gecko-try.servo-clone }}
+    - user: servo-gecko-try
+
+https://hg.mozilla.org/mozilla-central/:
+  hg.latest:
+    - target: {{ servo-gecko-try.m-c }}
+    - user: servo-gecko-try
+
+https://hg.mozilla.org/integration/autoland/:
+  hg.latest:
+    - target: {{ servo-gecko-try.autoland }}
+    - user: servo-gecko-try
+
+http://hg.mozilla.org/hgcustom/version-control-tools/:
+  hg.latest:
+    - target: {{ servo-gecko-try.vct }}
+    - user: servo-gecko-try
+
+/home/servo-gecko-try/.ssh/id_rsa.pub:
+   file.managed:
+    - user: servo-gecko-try
+    - group: servo-gecko-try
+    - contents_pillar: servo-gecko-try:servo:id_rsa.pub
+
+/home/servo-gecko-try/.ssh/id_rsa:
+  file.managed:
+    - user: servo-gecko-try
+    - group: servo-gecko-try
+    - mode: 600
+    - contents_pillar: servo-gecko-try:servo:id_rsa

--- a/servo-gecko-try/map.jinja
+++ b/servo-gecko-try/map.jinja
@@ -1,0 +1,8 @@
+{%
+  set servo-gecko-try = {
+    'servo-clone': '/home/servo/servo-clone',
+    'm-c': '/home/servo/m-c-clone',
+    'autoland': '/home/servo/autoland-clone',
+    'vct': '/home/servo/.mozbuild/verson-control-tools',
+  }
+%}

--- a/top.sls
+++ b/top.sls
@@ -39,3 +39,8 @@ base:
     - intermittent-tracker
     - nginx
     - salt.master
+
+  'servo-gecko-try':
+    - common
+    - git
+    - servo-gecko-try


### PR DESCRIPTION
Roughly the same setup as intermittent-tracker, with the notable difference
that we manage ssh keys for the user and they live in the pillar.

I fully expect the tests to break at first and will ping someone when I think it's properly ready for review -- feel free to ignore this PR for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/700)
<!-- Reviewable:end -->
