### PR TITLE
Add the Mozilla central servo sync account as an operator.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -128,6 +128,7 @@ secret = "{{ secrets['web-secret'] }}"
     "chenpighead",
     "hiikezoe",
     "jryans",
+    "moz-servo-sync",
 ] %}
 
 {% set try = [


### PR DESCRIPTION
r? @edunham 

@globau tells me that https://github.com/moz-servo-sync is the account that sheriff backouts will appear as. In order to auto-approve and support `treeclosed`, I was thinking that it would make sense to make it an `operator`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/702)
<!-- Reviewable:end -->
