### PR TITLE
Bump Salt timeout to 60 seconds

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -15,7 +15,8 @@
             'keep_jobs': 0,
             'pillar_roots': {
               'base': [ '/srv/pillar' ]
-            }
+            },
+            'timeout': 60
           }
         },
         'Ubuntu': {


### PR DESCRIPTION
This provides slow machines (such as some of the Macs)
more time to respond.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/703)
<!-- Reviewable:end -->
