### PR TITLE
Move the max to 9002 so that we can use 9001 and reasonable numbers.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -11,7 +11,7 @@ app_client_id = "{{ secrets['app-client-id'] }}"
 app_client_secret = "{{ secrets['app-client-secret'] }}"
 
 # Priority values above max_priority will be refused.
-max_priority = 9001
+max_priority = 9002
 
 [web]
 host = "0.0.0.0"


### PR DESCRIPTION
r? @edunham or @Manishearth or @metajack 

(anybody, really)

See IRC convo at:
http://logs.glob.uno/?c=mozilla%23servo#c704856

This will allow `@bors-servo force r+ p=9000 treeclosed=9001` to work for Firefox.

cc @globau

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/705)
<!-- Reviewable:end -->
