### PR TITLE
Remove all old logs, not just the zipped up ones.

### DIFF
--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -90,7 +90,7 @@ buildbot-github-listener:
 
 remove-old-build-logs:
   cron.present:
-    - name: 'find {{ common.servo_home }}/buildbot/master/*/*.bz2 -mtime +5 -delete'
+    - name: 'find {{ common.servo_home }}/buildbot/master/*/* -mtime +5 -delete'
     - user: root
     - minute: 1
     - hour: 0


### PR DESCRIPTION
Fixes https://github.com/servo/saltfs/issues/506

The only stuff in these directories is the various logs put there by Buildbot, so we're safe to ditch them. 

5 days might be a bit to aggressive but it's what we have before to no major ill effects so I left it. If we want partial logs for a month, it'd be just as easy to run a separate cron job to delete the non-zipped files a bit less enthusiastically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/710)
<!-- Reviewable:end -->
