### PR TITLE
Handle Homebrew renaming `mobile-shell` to `mosh`

### DIFF
--- a/admin/init.sls
+++ b/admin/init.sls
@@ -5,11 +5,9 @@ admin-packages:
   pkg.installed:
     - pkgs:
       - tmux
-      {% if grains['os'] != 'MacOS' %}
       - mosh
+      {% if grains['os'] != 'MacOS' %}
       - screen # Installed by default on OS X
-      {% else %}
-      - mobile-shell
       {% endif %}
 
 {% if grains['os'] != 'MacOS' and grains.get('virtual_subtype', '') != 'Docker' %}


### PR DESCRIPTION
Homebrew left in an alias for `mobile-shell` so the `mosh` package
actually installs correctly, but Salt's pkg.installed state then tries
to verify the installation by checking the installed packages.
That list only shows `mosh` and not the `mobile-shell` alias,
causing the state the fail.

Update to the new name, which is also consistent with everyone else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/724)
<!-- Reviewable:end -->
