### PR TITLE
Manage sshd_config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ matrix:
       os: osx
       osx_image: xcode8
     - env:
+        - SALT_NODE_ID=servo-mac2
+        - SALT_FROM_SCRATCH=true
+      os: osx
+      osx_image: xcode6.4
+    - env:
         - SALT_NODE_ID=servo-linux1
         - SALT_FROM_SCRATCH=true
       os: linux
@@ -50,6 +55,11 @@ matrix:
         - SALT_FROM_SCRATCH=false
       os: osx
       osx_image: xcode8
+    - env:
+        - SALT_NODE_ID=servo-mac2
+        - SALT_FROM_SCRATCH=false
+      os: osx
+      osx_image: xcode6.4
     - env:
         - SALT_NODE_ID=servo-linux1
         - SALT_FROM_SCRATCH=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - SALT_NODE_ID=servo-mac1
         - SALT_FROM_SCRATCH=true
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode8
     - env:
         - SALT_NODE_ID=servo-linux1
         - SALT_FROM_SCRATCH=true
@@ -49,7 +49,7 @@ matrix:
         - SALT_NODE_ID=servo-mac1
         - SALT_FROM_SCRATCH=false
       os: osx
-      osx_image: xcode8.3
+      osx_image: xcode8
     - env:
         - SALT_NODE_ID=servo-linux1
         - SALT_FROM_SCRATCH=false

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -141,6 +141,7 @@ else
         ./test.py sls.servo-build-dependencies.android
     fi
 
+    ./test.py sls.admin
     # Salt doesn't support timezone.system on OSX
     # See https://github.com/saltstack/salt/issues/31345
     if [[ ! "${SALT_NODE_ID}" =~ servo-mac.* ]]; then

--- a/admin/files/sshd_config
+++ b/admin/files/sshd_config
@@ -1,0 +1,25 @@
+HostKey /etc/ssh/ssh_host_ed25519_key
+KexAlgorithms curve25519-sha256@libssh.org
+Ciphers chacha20-poly1305@openssh.com
+
+# Only pubkey authentication is enabled, i.e. password logins are disabled
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+# TODO: Disable root login after creating per-user accounts
+PermitRootLogin yes
+
+MaxAuthTries 2
+LoginGraceTime 1m
+
+{% if grains['kernel'] == 'Linux' %}
+UsePAM yes
+# PAM does this
+PrintMotd no
+{% endif %}
+
+UsePrivilegeSeparation sandbox
+# LogLevel VERBOSE logs user's key fingerprint on login.
+# Needed to have a clear audit track of which key was using to log in.
+LogLevel VERBOSE

--- a/tests/sls/admin/valid_sshd_config.py
+++ b/tests/sls/admin/valid_sshd_config.py
@@ -1,0 +1,20 @@
+import subprocess
+
+from tests.util import Failure, Success
+
+
+def run():
+    proc = subprocess.Popen(
+        ['sshd', '-T', '-f', '/etc/ssh/sshd_config'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    _, stderr = proc.communicate()
+
+    if proc.returncode != 0:
+        return Failure(
+            'Invalid sshd_config file:', stderr
+        )
+
+    return Success('SSHD config file is valid')


### PR DESCRIPTION
This is based on Mozilla's Modern sshd_config from:
https://wiki.mozilla.org/Security/Guidelines/OpenSSH

Note that root login is still allowed,
because we have not yet set up per-user accounts.

Add a test to ensure the sshd_config file is properly parsed and
validated by the OpenSSH version on the machine to help guard
against this behavior.

Additionally, our new 10.11.6 macOS machines have Xcode 8.2 installed.
Use xcode8 on Travis, which maps to Xcode 8gm and macOS 10.11.
This is also important to help ensure tests like the sshd config test
match the behavior we'll see in the field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/725)
<!-- Reviewable:end -->
