### PR TITLE
Add upstream WPT sync webhook server

### DIFF
--- a/.travis/test_pillars/top.sls
+++ b/.travis/test_pillars/top.sls
@@ -7,6 +7,7 @@ base:
     - match: pcre
     - buildbot.master
     - homu
+    - wpt-sync
 
   'servo-(linux|mac|macpro)\d+':
     - match: pcre

--- a/.travis/test_pillars/wpt-sync.sls
+++ b/.travis/test_pillars/wpt-sync.sls
@@ -1,0 +1,2 @@
+'wpt-sync':
+  'upstream-wpt-sync-token': 'TEST_UPSTREAM_WPT_SYNC_TOKEN'

--- a/docs/upstream-wpt-webhook.md
+++ b/docs/upstream-wpt-webhook.md
@@ -1,0 +1,12 @@
+# Upstream web-platform-tests sync service
+
+This service runs a flask server that acts as a Github webhook target.
+It watches for changes to pull requests, and if a pull request contains
+changes to the vendored web-platform-tests directory, it transplants
+those changes to a local clone of the w3c/web-platform-tests
+repository and makes a new pull request upstream.
+
+This service ensures that when changes to the upstream tests are merged
+in servo/servo, they are also replicated in the upstream test repository
+as soon as possible to avoid the two repositories getting out of sync.
+See [the project's README](https://github.com/servo-automation/upstream-wpt-sync-webhook/blob/master/README.md) for more details.

--- a/nginx/default
+++ b/nginx/default
@@ -16,6 +16,9 @@ server {
   location /intermittent-tracker/ {
     proxy_pass http://localhost:5000/;
   }
+  location /upstream-wpt-webhook/ {
+    proxy_pass http://localhost:5001/;
+  }
   location /intermittent-failure-tracker/ {
     proxy_pass http://localhost:5002/;
   }

--- a/top.sls
+++ b/top.sls
@@ -44,5 +44,6 @@ base:
     - homu
     - intermittent-tracker
     - intermittent-failure-tracker
+    - upstream-wpt-webhook
     - nginx
     - salt.master

--- a/upstream-wpt-webhook/files/config.json
+++ b/upstream-wpt-webhook/files/config.json
@@ -1,0 +1,8 @@
+{
+    "token": "{{ pillar["wpt-sync"]["upstream-wpt-sync-token"] }}",
+    "username": "servo-wpt-sync",
+    "wpt_path": "./web-platform-tests",
+    "upstream_org": "w3c",
+    "servo_org": "servo",
+    "port": 5001
+}

--- a/upstream-wpt-webhook/files/wpt-webhook.conf
+++ b/upstream-wpt-webhook/files/wpt-webhook.conf
@@ -1,0 +1,11 @@
+exec /home/wpt-sync/upstream-wpt-sync-webhook/_venv/bin/upstream_wpt_webhook
+
+setuid wpt-sync
+setgid wpt-sync
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [016]
+
+env HOME=/home/wpt-sync
+
+chdir /home/wpt-sync/upstream-wpt-sync-webhook

--- a/upstream-wpt-webhook/init.sls
+++ b/upstream-wpt-webhook/init.sls
@@ -1,0 +1,70 @@
+{% from tpldir ~ '/map.jinja' import webhook %}
+
+include:
+  - python
+
+upstream-wpt-webhook:
+  group.present:
+    - members:
+      - wpt-sync
+    - require:
+      - user: wpt-sync
+  user.present:
+    - name: wpt-sync
+    - fullname: WPT Sync Webhook
+    - shell: /bin/bash
+    - home: /home/wpt-sync
+  virtualenv.managed:
+    - name: /home/wpt-sync/upstream-wpt-sync-webhook/_venv
+    - venv_bin: virtualenv-3.5
+    - python: python3
+    - user: wpt-sync
+    - system_site_packages: False
+    - require:
+      - pkg: python3
+      - pip: virtualenv
+  pip.installed:
+    - pkgs:
+      - git+https://github.com/servo-automation/upstream-wpt-sync-webhook@{{ webhook.rev }}
+    - bin_env: /home/wpt-sync/upstream-wpt-sync-webhook/_venv
+    - upgrade: True
+    - require:
+      - virtualenv: upstream-wpt-webhook
+  {% if grains.get('virtual_subtype', '') != 'Docker' %}
+  service.running:
+    - enable: True
+    - name: wpt-webhook
+    - require:
+      - pip: upstream-wpt-webhook
+      - git: web-platform-tests
+    - watch:
+      - file: /home/wpt-sync/upstream-wpt-sync-webhook/config.json
+      - file: /etc/init/wpt-webhook.conf
+      - pip: upstream-wpt-webhook
+  {% endif %}
+
+web-platform-tests:
+  git.latest:
+    - user: wpt-sync
+    - branch: master
+    - depth: 1
+    - target: /home/wpt-sync/upstream-wpt-sync-webhook/web-platform-tests
+    - name: https://github.com/w3c/web-platform-tests.git
+
+/home/wpt-sync/upstream-wpt-sync-webhook/config.json:
+  file.managed:
+    - source: salt://{{ tpldir }}/files/config.json
+    - template: jinja
+    - user: wpt-sync
+    - group: wpt-sync
+    - mode: 644
+
+/etc/init/wpt-webhook.conf:
+  file.managed:
+    - source: salt://{{ tpldir }}/files/wpt-webhook.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: upstream-wpt-webhook
+      - file: /home/wpt-sync/upstream-wpt-sync-webhook/config.json

--- a/upstream-wpt-webhook/map.jinja
+++ b/upstream-wpt-webhook/map.jinja
@@ -1,0 +1,5 @@
+{%
+  set webhook = {
+    'rev': '21cc4c1b9c46aa5d955611100d2bae716a163179'
+  }
+%}


### PR DESCRIPTION
This is flagrantly based off of the setup for intermittent-tracker. I've added the appropriate secret to servo-master1's pillar, and I've also cloned the web-platform-tests repo to /srv/web-platform-tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/733)
<!-- Reviewable:end -->
