### PR TITLE
Restart services when upgrading python packages.

### DIFF
--- a/homu/init.sls
+++ b/homu/init.sls
@@ -53,6 +53,7 @@ homu:
     - watch:
       - file: /home/servo/homu/cfg.toml
       - file: /etc/init/homu.conf
+      - pip: homu
   {% endif %}
 
 {{ salt['file.dirname'](homu.db) }}:

--- a/intermittent-failure-tracker/init.sls
+++ b/intermittent-failure-tracker/init.sls
@@ -32,6 +32,7 @@ intermittent-failure-tracker:
     - watch:
       - file: /home/servo/intermittent-failure-tracker/config.json
       - file: /etc/init/failure-tracker.conf
+      - pip: intermittent-failure-tracker
   {% endif %}
 
 /home/servo/intermittent-failure-tracker/config.json:

--- a/intermittent-tracker/init.sls
+++ b/intermittent-tracker/init.sls
@@ -33,6 +33,7 @@ intermittent-tracker:
     - watch:
       - file: /home/servo/intermittent-tracker/config.json
       - file: /etc/init/tracker.conf
+      - pip: intermittent-tracker
   {% endif %}
 
 /home/servo/intermittent-tracker/config.json:


### PR DESCRIPTION
Right now we install upgrades of python packages from git repositories, but the services are never restarted so we continue using the old packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/748)
<!-- Reviewable:end -->
