### PR TITLE
Update intermittent failure tracker

### DIFF
--- a/intermittent-failure-tracker/map.jinja
+++ b/intermittent-failure-tracker/map.jinja
@@ -1,5 +1,5 @@
 {%
   set tracker = {
-    'rev': '2acbb5043eb67b9a73c2cac6bb9a03b8e9b9bd0c'
+    'rev': 'f905ecaac1b0849b0f77603a12e884e69ec16209'
   }
 %}

--- a/nginx/default
+++ b/nginx/default
@@ -21,6 +21,10 @@ server {
   }
   location /intermittent-failure-tracker/ {
     proxy_pass http://localhost:5002/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Script-Name /intermittent-failure-tracker;
   }
 }
 


### PR DESCRIPTION
This update makes the interface at http://build.servo.org/intermittent-failure-tracker/search more useful for determining what intermittent failures are most frequent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/754)
<!-- Reviewable:end -->
