### PR TITLE
Install aws-cli on linux builders.

### DIFF
--- a/servo-build-dependencies/aws.sls
+++ b/servo-build-dependencies/aws.sls
@@ -1,0 +1,10 @@
+include:
+  - python
+
+aws-cli:
+  pip.installed:
+    - pkgs:
+      - awscli
+    - require:
+      - pkg: pip
+      - pip: virtualenv

--- a/top.sls
+++ b/top.sls
@@ -31,6 +31,7 @@ base:
     - match: pcre
     - buildbot.slave
     - servo-build-dependencies
+    - servo-build-dependencies.aws
     - servo-build-dependencies.ci
     - xvfb
 


### PR DESCRIPTION
@asajeffrey says that this would be useful for the linux-nightly builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/756)
<!-- Reviewable:end -->
