### PR TITLE
Add AWS credentials to buildbot aws steps.

### DIFF
--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -217,7 +217,7 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
                     step_env += envs.upload_nightly
 
             # Provide credentials where necessary
-            if arg == 'aws':
+            elif arg == 'aws':
                 step_kwargs['logEnviron'] = False
                 step_env += envs.upload_nightly
                 step_desc += [arg]

--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -216,6 +216,12 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
                     step_kwargs['logEnviron'] = False
                     step_env += envs.upload_nightly
 
+            # Provide credentials where necessary
+            if arg == 'aws':
+                step_kwargs['logEnviron'] = False
+                step_env += envs.upload_nightly
+                step_desc += [arg]
+
             # Capture any logfiles
             elif re.match('--log-.*', arg):
                 logfile = next(args)


### PR DESCRIPTION
Add the AWS credentials to any buildbot steps running `aws`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/760)
<!-- Reviewable:end -->
