### PR TITLE
Rustup might not be fully installed even if ~/.rustup and ~/.cargo exist

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -11,7 +11,7 @@ servo-dependencies:
     - runas: servo
     - creates:
       - {{ common.servo_home }}/.rustup
-      - {{ common.servo_home }}/.cargo
+      - {{ common.servo_home }}/.cargo/bin/rustup
   pkg.installed:
     {% if grains['os'] == 'Ubuntu' %}
     - require:


### PR DESCRIPTION
This is currently the case on `servo-mac2` for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/767)
<!-- Reviewable:end -->
