### PR TITLE
Add rustup-installed binaries to $PATH on Mac

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -78,6 +78,14 @@ build_mac = build_common + Environment({
     'SERVO_CACHE_DIR': '/Users/servo/.servo',
     'OPENSSL_INCLUDE_DIR': '/usr/local/opt/openssl/include',
     'OPENSSL_LIB_DIR': '/usr/local/opt/openssl/lib',
+    'PATH': ':'.join([
+        '{{ common.servo_home }}/.cargo/bin',
+        '/usr/local/bin',
+        '/usr/bin',
+        '/bin',
+        '/usr/sbin',
+        '/sbin',
+    ]),
 })
 
 


### PR DESCRIPTION
I missed this in https://github.com/servo/saltfs/pull/762.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/771)
<!-- Reviewable:end -->
