### PR TITLE
Upgrade sccache

### DIFF
--- a/servo-build-dependencies/ci-map.jinja
+++ b/servo-build-dependencies/ci-map.jinja
@@ -2,20 +2,20 @@
   set sccache = salt['grains.filter_by']({
       'defaults': {
         'destination': '/usr/local/bin/sccache',
-        'version': '2017-05-12',
+        'version': '2018-01-09',
       },
       'MacOS': {
         'platform': 'x86_64-apple-darwin',
-        'sha384': 'b967518efa0d612baf683d3c69a73009fd00c3a58f8445f156701cd0c0579c4f4815890a6922a8f85989366e7cbe7940'
+        'sha384': 'cd8dac86c250e8b5c59e231dc413ead48e97e7c9630d9a30ae1f9b16d738ac8004ebbdfe04351df71ced582f4022393d'
       },
       'Ubuntu': {
         'platform': 'x86_64-unknown-linux-musl',
-        'sha384': '901e93dd5536c251f6daae8bfdcc7db1c430f419ceb6f47e25e1cdaf0671c7e465cfcb7bd7d6c683dbc7a2d7fdc45b83'
+        'sha384': '6f005785e1178b30b3629dd1c69539a1df608216309ec9cded093e5447e9787cb462f36c7025a7564f3c4c93e0e4a8a2'
       },
       'Windows': {
         'destination': 'C:\sccache\sccache.exe',
         'platform': 'x86_64-pc-windows-msvc',
-        'sha384': '96c83298fc00874371eb1e2ee3d30d0dcc35a34240a8782509019ed1d6477dd9cd888a40cf9af12ef74c935fa0585697'
+        'sha384': '2f25ee8e1e21bced7af8c16c4c94831d188729588eeef72f494b0af620a04d25635d6f939842db6a8fddb3beb27460e1'
       }
     },
     base='defaults',

--- a/servo-build-dependencies/ci.sls
+++ b/servo-build-dependencies/ci.sls
@@ -4,7 +4,7 @@
 sccache:
   file.managed:
     - name: {{ sccache.destination }}
-    - source: https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/{{ sccache.version }}-sccache-{{ sccache.platform }}
+    - source: https://servo-deps.s3.amazonaws.com/sccache/{{ sccache.version }}-sccache-{{ sccache.platform }}
     - source_hash: sha384={{ sccache.sha384 }}
     - user: {{ root.user }}
     {% if grains['os'] != 'Windows' %}


### PR DESCRIPTION
This puts the binaries in a s3 bucket that we control and upgrades to the latest version. This should finally fix https://github.com/servo/servo/issues/19495.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/774)
<!-- Reviewable:end -->
