### PR TITLE
Add proxychains package for warc testing

### DIFF
--- a/servo-build-dependencies/aws.sls
+++ b/servo-build-dependencies/aws.sls
@@ -12,3 +12,9 @@ aws-cli:
 unzip:
   pkg.installed:
     - name: unzip
+
+# Proxychains is used for performance testing on archived web content
+# https://github.com/servo/servo-warc-tests/
+proxychains:
+  pkg.installed:
+    - name: proxychains


### PR DESCRIPTION
Proxychains is used for performance testing on archived web content. https://github.com/servo/servo-warc-tests/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/778)
<!-- Reviewable:end -->
