### PR TITLE
Import module for missing user requirement.

### DIFF
--- a/buildbot/slave/init.sls
+++ b/buildbot/slave/init.sls
@@ -1,6 +1,7 @@
 {% from 'common/map.jinja' import common %}
 
 include:
+  - common
   - python
 
 buildbot-slave-dependencies:


### PR DESCRIPTION
This fixes a longstanding problem when highstating on servo-mac4, since the user requirement is defined in common/init.sls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/782)
<!-- Reviewable:end -->
