### PR TITLE
Provide credentials to nightly WPT sync job

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -1,6 +1,7 @@
 from buildbot.plugins import util
 from passwords import GITHUB_DOC_TOKEN, GITHUB_HOMEBREW_TOKEN
 from passwords import S3_UPLOAD_ACCESS_KEY_ID, S3_UPLOAD_SECRET_ACCESS_KEY
+from passwords import WPT_SYNC_PR_CREATION_TOKEN
 
 
 class Environment(dict):
@@ -152,4 +153,8 @@ upload_nightly = Environment({
     'AWS_ACCESS_KEY_ID': S3_UPLOAD_ACCESS_KEY_ID,
     'AWS_SECRET_ACCESS_KEY': S3_UPLOAD_SECRET_ACCESS_KEY,
     'GITHUB_HOMEBREW_TOKEN': GITHUB_HOMEBREW_TOKEN,
+})
+
+sync_wpt = Environment({
+    'WPT_SYNC_TOKEN': WPT_SYNC_PR_CREATION_TOKEN,
 })

--- a/buildbot/master/files/config/factories.py
+++ b/buildbot/master/files/config/factories.py
@@ -222,6 +222,15 @@ class StepsYAMLParsingStep(buildstep.ShellMixin, buildstep.BuildStep):
                 step_env += envs.upload_nightly
                 step_desc += [arg]
 
+            elif arg == './etc/ci/update-wpt-checkout':
+                update_arg = next(args)
+                step_desc = [update_arg]
+
+                # Provide credentials where necessary
+                if update_arg == 'open-pr':
+                    step_kwargs['logEnviron'] = False
+                    step_env += envs.sync_wpt
+
             # Capture any logfiles
             elif re.match('--log-.*', arg):
                 logfile = next(args)

--- a/buildbot/master/files/config/passwords.py
+++ b/buildbot/master/files/config/passwords.py
@@ -10,3 +10,5 @@ S3_UPLOAD_ACCESS_KEY_ID = \
 S3_UPLOAD_SECRET_ACCESS_KEY = \
     "{{ buildbot_credentials['s3-upload-secret-access-key'] }}"
 GITHUB_STATUS_TOKEN = "{{ buildbot_credentials['gh-status-token'] }}"
+WPT_SYNC_PR_CREATION_TOKEN = \
+    "{{ wpt_sync_credentials['upstream-wpt-sync-token'] }}"

--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -38,6 +38,7 @@ deploy-{{ common.servo_home }}/buildbot/master:
     - context:
         common: {{ common }}
         buildbot_credentials: {{ pillar['buildbot']['credentials'] }}
+        wpt_sync_credentials: {{ pillar['wpt-sync'] }}
     - require:
       - user: servo
 


### PR DESCRIPTION
This will give us more useful information by actually creating a PR with the results of syncing with upstream. We can choose to disregard it without any issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/783)
<!-- Reviewable:end -->
