### PR TITLE
Remove global CI environment variables

### DIFF
--- a/buildbot/master/files/config/environments.py
+++ b/buildbot/master/files/config/environments.py
@@ -49,9 +49,7 @@ doc = Environment({
 })
 
 build_common = Environment({
-    'RUST_BACKTRACE': '1',
     'BUILD_MACHINE': str(util.Property('slavename')),
-    'SCCACHE_IDLE_TIMEOUT': '0',
 })
 
 build_windows_msvc = build_common + Environment({


### PR DESCRIPTION
These variables are being moved to the servo/servo repo.
Keep the BUILD_MACHINE variable as it relies on Buildbot interpolation,
and cannot be moved into servo/servo.

Helps with #770; depends on servo/servo#19882.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/784)
<!-- Reviewable:end -->
