### PR TITLE
Fix Windows minion targeting

### DIFF
--- a/top.sls
+++ b/top.sls
@@ -36,6 +36,7 @@ base:
     - xvfb
 
   'servo-windows\d+':
+    - match: pcre
     - servo-build-dependencies.ci
 
   'servo-master\d+':


### PR DESCRIPTION
Use the correct type of targeting so the Windows minions
actually have states to run during highstates.

Fixes #766.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/785)
<!-- Reviewable:end -->
