### PR TITLE
Add Salt testing root setup/cleanup scripts

### DIFF
--- a/salt/files/master/ADMIN_README
+++ b/salt/files/master/ADMIN_README
@@ -1,15 +1,21 @@
-Note: this directory is meant to be used to TEMPORARILY test out changes to our
-Salt configurations on the live builders. To use it, clone the saltfs repo into
-this folder, and Salt will read from it (/tmp/salt-testing-root/saltfs).
-This folder takes precedence over gitfs (which reads file from the master
-branch of the saltfs repository), so it is important to follow a few guidelines:
+Note: this directory is meant to be used to TEMPORARILY test out changes
+to our Salt configurations on the live builders.
 
-- Avoid using this folder if possible: prefer to test changes locally using the
-steps under "Salt workflow" in the `docs/salt.md` file.
+To get started, clone the saltfs repo using the `setup.sh` script.
+Make any changes you want inside the `saltfs` directory.
+When you're done, make sure to run the `cleanup.sh` script.
 
-- If you do need to use this folder, use it only as long as you need it, and
-make sure to remove the cloned saltfs folder afterwards. Any files that are
-left dangling will continue to mask changes in the real saltfs repository.
+This folder takes precedence over gitfs
+(which reads file from the master branch of the saltfs repository),
+so it is important to follow a few guidelines:
 
-- There is only one of these folders, so if it's already in use, wait until it
-is empty again before testing your change.
+- Avoid using this folder if possible: prefer to test changes locally
+  using the steps under "Salt workflow" in the `docs/salt.md` file.
+
+- If you do need to use this folder, use it only as long as you need it,
+  and make sure to run the `cleanup.sh` script afterwards.
+  Any files that are left dangling will continue to mask changes
+  in the real saltfs repository.
+
+- There is only one of these folders, so if it's already in use,
+  wait until it is empty again before testing your change.

--- a/salt/files/master/cleanup.sh
+++ b/salt/files/master/cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${USER}" == "vagrant" ]]; then
+    echo 'Inside Vagrant, the Salt override directory is actually a mount.'
+    echo 'Refusing to delete your local checkout.'
+    exit 1
+fi
+
+exec rm -r saltfs/

--- a/salt/files/master/setup.sh
+++ b/salt/files/master/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+exec git clone https://github.com/servo/saltfs.git

--- a/salt/master.sls
+++ b/salt/master.sls
@@ -21,12 +21,39 @@ salt-master-dependencies:
       - service: salt-master
     {% endif %}
 
+{% if loop.index0 > 0 %}
+# Only the very first base file root should be used for testing
+{% continue %}
+{% endif %}
+
 {{ rootfs_parent_dir }}/ADMIN_README:
   file.managed:
     - user: root
     - group: root
     - mode: 644
     - source: salt://{{ tpldir }}/files/master/ADMIN_README
+    {% if grains.get('virtual_subtype', '') != 'Docker' %}
+    - require_in:
+      - service: salt-master
+    {% endif %}
+
+{{ rootfs_parent_dir }}/setup.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 755
+    - source: salt://{{ tpldir }}/files/master/setup.sh
+    {% if grains.get('virtual_subtype', '') != 'Docker' %}
+    - require_in:
+      - service: salt-master
+    {% endif %}
+
+{{ rootfs_parent_dir }}/cleanup.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 755
+    - source: salt://{{ tpldir }}/files/master/cleanup.sh
     {% if grains.get('virtual_subtype', '') != 'Docker' %}
     - require_in:
       - service: salt-master


### PR DESCRIPTION
I found versions of these on `servo-master1`
and thought they were a great idea,
so I've pulled them into Salt so we always have them.

I've also update the documentation,
and added a safety around a potential footgun inside Vagrant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/786)
<!-- Reviewable:end -->
