### PR TITLE
Add scripts to clean up all known build directories on build machines.

### DIFF
--- a/osx/files/remove-build-directories
+++ b/osx/files/remove-build-directories
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare -a builders=("mac-dev-unit" "mac-nightly" "mac-rel-css" "mac-rel-css1"
+                     "mac-rel-css2" "mac-rel-intermittent" "mac-rel-wpt1"
+                     "mac-rel-wpt2" "mac-rel-wpt3" "mac-rel-wpt4")
+
+declare -a targets=("doc" "release" "geckolib" "debug")
+
+for builder in "${builders[@]}"
+do
+  for target in "${targets[@]}"
+  do
+    rm -rf "/Users/servo/buildbot/slave/${builder}/build/target/${target}"
+  done
+done

--- a/osx/init.sls
+++ b/osx/init.sls
@@ -12,6 +12,13 @@
     - mode: 644
     - source: salt://{{ tpldir }}/files/profile
 
+/var/root/remove-build-directories:
+  file.managed:
+    - user: root
+    - group: wheel
+    - mode: 654
+    - source: salt://{{ tpldir }}/files/remove-build-directories
+
 disable-homebrew-analytics:
   homebrew_analytics.managed:
     - name: disabled

--- a/ubuntu/files/remove-build-directories
+++ b/ubuntu/files/remove-build-directories
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare -a builders=("android" "linux-dev" "linux-nightly" "linux-rel-css"
+                     "linux-rel-intermittent" "linux-rel-nogate"
+                     "linux-rel-wpt" "android-nightly" "arm32" "arm64")
+
+declare -a targets=("doc" "release" "geckolib" "debug")
+
+for builder in "${builders[@]}"
+do
+  for target in "${targets[@]}"
+  do
+    rm -rf "/home/servo/buildbot/slave/${builder}/build/target/${target}"
+  done
+done

--- a/ubuntu/init.sls
+++ b/ubuntu/init.sls
@@ -32,6 +32,13 @@
     - template: jinja
     - source: salt://{{ tpldir }}/files/sources.list
 
+/root/remove-build-directories:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 654
+    - source: salt://{{ tpldir }}/files/remove-build-directories
+
 refresh_pkg_db:
   module.run:
     - name: pkg.refresh_db


### PR DESCRIPTION
This is a stopgap measure until we put some sort of automation in place to avoid #797. I want to make it as easy as possible for anybody with SSH access to free up disk space on a build machine when we run out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/799)
<!-- Reviewable:end -->
