### PR TITLE
Add paulrouget to the list of reviewers

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -123,6 +123,7 @@ secret = "{{ secrets['web-secret'] }}"
     "notriddle",
     "nox",
     "pcwalton",
+    "paulrouget",
     "saneyuki",
     "SimonSapin",
     "shinglyu",


### PR DESCRIPTION
This is mostly to be able to do `@bors-servo r=XXX`. Often I get a simple r=me, without the @bors-servo snippet.
Also, happy to review anything about embedding and ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/801)
<!-- Reviewable:end -->
