### PR TITLE
Install the HTTPS apt transport.

### DIFF
--- a/.travis/install_salt.sh
+++ b/.travis/install_salt.sh
@@ -22,7 +22,7 @@ install_salt() {
 
         # Ensure curl is installed (is not present by default in Docker)
         ${SUDO} apt-get -y update
-        ${SUDO} apt-get -y install --no-install-recommends ca-certificates curl
+        ${SUDO} apt-get -y install --no-install-recommends ca-certificates curl apt-transport-https
 
         curl "https://repo.saltstack.com/apt/ubuntu/${os_release}/amd64/archive/2016.3.3/SALTSTACK-GPG-KEY.pub" | \
             ${SUDO} apt-key add -


### PR DESCRIPTION
This should fix the ongoing TravisCI networking issues, based on https://askubuntu.com/questions/165676/how-do-i-fix-a-e-the-method-driver-usr-lib-apt-methods-http-could-not-be-foun.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/805)
<!-- Reviewable:end -->
