### PR TITLE
Accommodate changes to Python homebrew formulas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - SALT_NODE_ID=servo-mac1
         - SALT_FROM_SCRATCH=true
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
     - env:
         - SALT_NODE_ID=servo-linux1
         - SALT_FROM_SCRATCH=true
@@ -49,7 +49,7 @@ matrix:
         - SALT_NODE_ID=servo-mac1
         - SALT_FROM_SCRATCH=false
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
     - env:
         - SALT_NODE_ID=servo-linux1
         - SALT_FROM_SCRATCH=false

--- a/.travis/dispatch.sh
+++ b/.travis/dispatch.sh
@@ -69,6 +69,10 @@ setup_test_venv() {
     fi
     travis_fold_start 'test_venv.install_python3' \
         'Setting up Python 3 virtualenv for testing'
+    if [[ "${SALT_NODE_ID}" =~ servo-mac.* ]]; then
+        brew update
+        brew upgrade python
+    fi
     # Use the system Python 3 to make it easy to run tests on fresh hosts
     # Make sure dependencies are installed (like `python3-venv` on Debian derivatives)
     salt_call --retcode-passthrough state.sls python
@@ -139,7 +143,7 @@ else
 
     # Salt doesn't support timezone.system on OSX
     # See https://github.com/saltstack/salt/issues/31345
-    if [[ ! "${SALT_NODE_ID}" =~ servo-mac* ]]; then
+    if [[ ! "${SALT_NODE_ID}" =~ servo-mac.* ]]; then
         ./test.py sls.common
     fi
 fi

--- a/python/init.sls
+++ b/python/init.sls
@@ -1,10 +1,22 @@
+{% if grains['os'] == 'MacOS' %}
+
+python2:
+  pkg.installed:
+    - pkgs:
+      - python@2
+    - refresh: True
+
+python3:
+  pkg.installed:
+    - pkgs:
+      - python
+
+{% else %}
+
 python2:
   pkg.installed:
     - pkgs:
       - python
-    {% if grains['os'] == 'MacOS' %}
-    - refresh: True
-    {% endif %}
 
 python3:
   pkg.installed:
@@ -17,6 +29,8 @@ python3:
       - python3-venv
       {% endif %}
       {% endif %}
+
+{% endif %}
 
 {% if grains['os'] == 'Ubuntu' %}
 python2-dev:
@@ -31,7 +45,7 @@ pip:
       {% if grains['os'] in ['CentOS', 'Fedora', 'Ubuntu'] %}
       - python-pip
       {% elif grains['os'] == 'MacOS' %}
-      - python # pip is included with python in homebrew
+      - python@2 # pip is included with python in homebrew
       {% endif %}
     - reload_modules: True
 


### PR DESCRIPTION
These changes allow the TravisCI macOS builds to pass, and were derived from https://brew.sh/2018/01/19/homebrew-1.5.0/ and trial and error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/807)
<!-- Reviewable:end -->
