### PR TITLE
Remove travis gating for webrender.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -92,10 +92,6 @@ secret = "{{ secrets['web-secret'] }}"
         "extra_reviewers": [ "behnam" ],
     },
     "unicode-script": {},
-    "webrender": {
-        "extra_reviewers": [ "nical", "jrmuizel", "Gankro" ],
-    },
-    "webrender_traits": {},
 } %}
 
 {% set reviewers = [
@@ -109,10 +105,12 @@ secret = "{{ secrets['web-secret'] }}"
     "edunham",
     "emilio",
     "frewsxcv",
+    "Gankro",
     "glennw",
     "heycam",
     "jdm",
     "jgraham",
+    "jrmuizel",
     "KiChjang",
     "kmcallister",
     "kvark",
@@ -123,6 +121,7 @@ secret = "{{ secrets['web-secret'] }}"
     "michaelwu",
     "mrobinson",
     "Ms2ger",
+    "nical",
     "notriddle",
     "nox",
     "paulrouget",


### PR DESCRIPTION
Having the travis-ci gate enabled is causing several issues for
the WR repo at the moment (mostly timeouts, but also complicating
updating the Linux version used by the builders).

This moves the WR reviewers to the main reviewers list. This does
give those named reviewers extra repo privileges over what the
previous configuration. I'm not sure if there's a better way to
remove the WR gating while also keeping WR reviewer status.

Fixes #803.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/820)
<!-- Reviewable:end -->
