### PR TITLE
Ignore installed copies of pip dependencies.

### DIFF
--- a/buildbot/slave/init.sls
+++ b/buildbot/slave/init.sls
@@ -9,6 +9,7 @@ buildbot-slave-dependencies:
     - pkgs:
       - buildbot-slave == 0.8.12
       - twisted == 16.6.0 # NOTE: keep in sync with buildbot-master sls
+    - ignore_installed: True
     - require:
       - pkg: pip
 

--- a/python/init.sls
+++ b/python/init.sls
@@ -55,5 +55,6 @@ virtualenv:
   pip.installed:
     - pkgs:
       - virtualenv == 14.0.6
+    - ignore_installed: True
     - require:
       - pkg: pip

--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -101,6 +101,7 @@ servo-dependencies:
     - require:
       - pkg: pip
       - pip: virtualenv
+    - ignore_installed: True
   {% endif %}
 
 {% if grains['os'] == 'Ubuntu' %}


### PR DESCRIPTION
For reasons that are unclear to me, pip is suddenly complaining on TravisCI's macOS builders when the version of dependencies that we are trying to install already exist. These changes make that problem disappear so we can make other changes to salt. Fixes #829.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/830)
<!-- Reviewable:end -->
