### PR TITLE
Require v4.0 of LLVM and friends

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -18,6 +18,7 @@ servo-dependencies:
       - pkgrepo: cmake-ppa
       - pkgrepo: gcc-ppa
       - pkgrepo: ffmpeg-ppa
+      - pkgrepo: llvm-deb
     {% endif %}
     - pkgs:
       - ccache
@@ -60,9 +61,9 @@ servo-dependencies:
       - libssl-dev
       - libswscale-dev
       - libswresample-dev
-      - llvm-3.5-dev
-      - libclang-3.5-dev
-      - clang-3.5
+      - llvm-4.0-dev
+      - libclang-4.0-dev
+      - clang-4.0
       - xorg-dev
       - xpra
       - xserver-xorg-input-void
@@ -122,6 +123,11 @@ gcc-ppa:
 ffmpeg-ppa:
   pkgrepo.managed:
     - ppa: jonathonf/ffmpeg-3
+
+llvm-deb:
+  pkgrepo.managed:
+    - name: 'deb http://apt.llvm.org/{{ grains['oscodename'] }}/ llvm-toolchain-{{ grains['oscodename'] }}-4.0 main'
+    - key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
 
 multiverse:
   pkgrepo.managed:


### PR DESCRIPTION
Bindgen needs LLVM 3.9 or higher.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/841)
<!-- Reviewable:end -->
