### PR TITLE
Remove all build artifacts instead of specific targets.

### DIFF
--- a/ubuntu/files/remove-build-directories
+++ b/ubuntu/files/remove-build-directories
@@ -8,12 +8,7 @@ declare -a builders=("android" "android-x86" "linux-dev" "linux-nightly" "linux-
                      "linux-rel-intermittent" "linux-rel-nogate"
                      "linux-rel-wpt" "android-nightly" "arm32" "arm64")
 
-declare -a targets=("doc" "release" "geckolib" "debug")
-
 for builder in "${builders[@]}"
 do
-  for target in "${targets[@]}"
-  do
-    rm -rf "/home/servo/buildbot/slave/${builder}/build/target/${target}"
-  done
+  rm -rf "/home/servo/buildbot/slave/${builder}/build/target/"
 done


### PR DESCRIPTION
This will allow us to run the cleanup script on the cross builders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/870)
<!-- Reviewable:end -->
