### PR TITLE
Remove require: user: servo

### DIFF
--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -21,7 +21,6 @@ buildbot-master:
     # Buildbot must be restarted manually! See 'Buildbot administration' on the
     # wiki and https://github.com/servo/saltfs/issues/304.
     - require:
-      - user: servo
       - pip: buildbot-master
       - file: ownership-{{ common.servo_home }}/buildbot/master
       - file: /etc/init/buildbot-master.conf
@@ -41,8 +40,6 @@ deploy-{{ common.servo_home }}/buildbot/master:
         homu: {{ homu }}
         buildbot_credentials: {{ pillar['buildbot']['credentials'] }}
         wpt_sync_credentials: {{ pillar['wpt-sync'] }}
-    - require:
-      - user: servo
 
 ownership-{{ common.servo_home }}/buildbot/master:
   file.directory:


### PR DESCRIPTION
This only works if we have a  `servo: user.present` state somewhere; but
we don't, so we get the following error:

```
     Comment: The following requisites were not found:
                                 require:
                                     user: servo
```

We assume the user exists elsewhere anyway, though perhaps we could add
the user.present in case (but when i tried i wasn't able to make that
work)


r? @aneeshusa

cc @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/874)
<!-- Reviewable:end -->
