### PR TITLE
Add include: common to everything needing user: servo

### DIFF
--- a/buildbot/master/init.sls
+++ b/buildbot/master/init.sls
@@ -2,6 +2,7 @@
 {% from 'homu/map.jinja' import homu %}
 
 include:
+  - common
   - python
 
 buildbot-master:

--- a/homu/init.sls
+++ b/homu/init.sls
@@ -1,6 +1,7 @@
 {% from tpldir ~ '/map.jinja' import homu %}
 
 include:
+  - common
   - python
 
 homu-debugging-packages:

--- a/intermittent-failure-tracker/init.sls
+++ b/intermittent-failure-tracker/init.sls
@@ -1,6 +1,7 @@
 {% from tpldir ~ '/map.jinja' import tracker %}
 
 include:
+  - common
   - python
 
 intermittent-failure-tracker:

--- a/intermittent-tracker/init.sls
+++ b/intermittent-tracker/init.sls
@@ -1,6 +1,7 @@
 {% from tpldir ~ '/map.jinja' import tracker %}
 
 include:
+  - common
   - python
 
 tracker-debugging-packages:

--- a/servo-build-dependencies/arm.sls
+++ b/servo-build-dependencies/arm.sls
@@ -1,6 +1,9 @@
 {% from 'common/map.jinja' import common %}
 {% from tpldir ~ '/map.jinja' import arm %}
 
+include:
+  - common
+
 arm-dependencies:
   pkg.installed:
     - pkgs:

--- a/servo-build-dependencies/linux-gstreamer.sls
+++ b/servo-build-dependencies/linux-gstreamer.sls
@@ -1,5 +1,8 @@
 {% from 'common/map.jinja' import common %}
 
+include:
+  - common
+
 libs-gstreamer:
   archive.extracted:
     - name: {{ common.servo_home }}


### PR DESCRIPTION
Fixes intermittent "The following requisites were not found: `user: servo`" in buildbot states


See https://github.com/servo/saltfs/pull/874#issuecomment-415940277


r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/883)
<!-- Reviewable:end -->
