### PR TITLE
Gate servo/servo PRs on Taskcluster

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -98,6 +98,7 @@ secret = "{{ secrets['web-secret'] }}"
     "rust-websocket": {},
     "servo": {
         "travis": False,
+        "taskcluster": True,
     },
     "saltfs": {},
     "servo-starters": {},


### PR DESCRIPTION
Taskcluster should be green since https://github.com/servo/servo/pull/21776, let’s keep it that way!

CC https://github.com/servo/saltfs/issues/559

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/888)
<!-- Reviewable:end -->
