### PR TITLE
Switch to https://build.servo.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,6 @@ matrix:
 script: .travis/dispatch.sh
 
 notifications:
-  webhooks: http://build.servo.org:54856/travis
+  webhooks: https://build.servo.org/homu/travis
   irc: "irc.mozilla.org#servo-bots"
 

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -232,7 +232,7 @@ c['builders'] = [
 
 c['status'] = [
     status_push.HttpStatusPush(
-        serverUrl='http://build.servo.org:54856/buildbot',
+        serverUrl='https://build.servo.org/homu/buildbot',
         extra_post_params={'secret': HOMU_BUILDBOT_SECRET},
     ),
     html.WebStatus(

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -202,7 +202,7 @@ secret = "{{ secrets['web-secret'] }}"
 ] %}
 
 [repo.servo.buildbot]
-url = "http://build.servo.org"
+url = "https://build.servo.org"
 secret = "{{ secrets["buildbot-secret"] }}"
 builders = [
     "linux-dev",

--- a/nginx/default
+++ b/nginx/default
@@ -1,10 +1,18 @@
 server {
   listen 80 default_server;
+  server_name _;
+  server_tokens off;
+  return 307 https://$host$request_uri;
+}
+server {
+  listen 443 ssl;
   server_name build.servo.org;
+  server_tokens off;
   ssl_certificate /etc/letsencrypt/live/build.servo.org/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/build.servo.org/privkey.pem;
+  ssl_protocols TLSv1.2;
+  ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256;
 
-  listen 443 ssl;
 
   location / {
     proxy_pass http://localhost:8010/;

--- a/servo-build-dependencies/linux-gstreamer.sls
+++ b/servo-build-dependencies/linux-gstreamer.sls
@@ -6,7 +6,7 @@ include:
 libs-gstreamer:
   archive.extracted:
     - name: {{ common.servo_home }}
-    - source: http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz
+    - source: https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz
     - source_hash: sha512=82ec74cd893592b5eefaa7f666bfb51bf70c09bd91b2a34038ff6d46d851b0c9ce1784a56bce1e01c79388296c4d3245d7542e79273c7f372cbc9d35fb1bcd87
     - archive_format: tar
     - user: servo


### PR DESCRIPTION
@jdm 
I don't want to just ping you, so I make this pull request.
This should help with https://github.com/servo/saltfs/issues/423#issuecomment-429399125, but is not tested with Vagrant.

- A next step would be to change it to a permanent http-to-https redirection and to activate HSTS.
- Current TLS config is [bad](https://www.hardenize.com/report/build.servo.org/1541002698#www_tls), therefore only modern ciphersuites should be allowed.
- http://build.servo.org:54856/travis might already not exist anymore?
- Please feel free to edit this pull request.

(Background: servo.org enforces [HSTS](https://www.hardenize.com/report/servo.org/1540988336#www_hsts) since [bug 1482947](https://bugzilla.mozilla.org/show_bug.cgi?id=1482947) and is ready to be HSTS-preloaded.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/906)
<!-- Reviewable:end -->
