### PR TITLE
Improve TLS config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,5 @@ matrix:
 script: .travis/dispatch.sh
 
 notifications:
-  webhooks: http://build.servo.org:54856/travis
   irc: "irc.mozilla.org#servo-bots"
 

--- a/nginx/default
+++ b/nginx/default
@@ -1,15 +1,18 @@
 server {
   listen 80 default_server;
+  listen 443 ssl;
   server_name build.servo.org;
+  server_tokens off;
+  ssl_protocols TLSv1.2 TLSv1;
+  ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
   ssl_certificate /etc/letsencrypt/live/build.servo.org/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/build.servo.org/privkey.pem;
-
-  listen 443 ssl;
 
   location / {
     proxy_pass http://localhost:8010/;
   }
-
   location /homu/ {
     proxy_pass http://localhost:54856/;
   }
@@ -21,6 +24,9 @@ server {
   }
   location /upstream-wpt-webhook/ {
     proxy_pass http://localhost:5001/;
+  }
+  location /github-buildbot/ {
+    proxy_pass http://localhost:9010/;
   }
   location /intermittent-failure-tracker/ {
     proxy_pass http://localhost:5002/;

--- a/servo-build-dependencies/linux-gstreamer.sls
+++ b/servo-build-dependencies/linux-gstreamer.sls
@@ -6,7 +6,7 @@ include:
 libs-gstreamer:
   archive.extracted:
     - name: {{ common.servo_home }}
-    - source: http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz
+    - source: https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz
     - source_hash: sha512=82ec74cd893592b5eefaa7f666bfb51bf70c09bd91b2a34038ff6d46d851b0c9ce1784a56bce1e01c79388296c4d3245d7542e79273c7f372cbc9d35fb1bcd87
     - archive_format: tar
     - user: servo


### PR DESCRIPTION
https://github.com/servo/saltfs/pull/906#issuecomment-436313032

Problem:
https://www.hardenize.com/report/build.servo.org#www_tls
https://www.ssllabs.com/ssltest/analyze.html?d=build.servo.org&hideResults=on

* Let's first switch all clients to https before we disable TLS 1.0. Just to be sure.
* [`server_tokens off;`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens) makes nginx return `Server: nginx` without any version number.
* ssl_session_cache: [official recommendation](https://nginx.org/en/docs/http/configuring_https_servers.html#optimization), [docs](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache)

An nginx restart is needed: [`service nginx restart`](https://github.com/servo/servo/wiki/Buildbot-administration)
You can test with `nginx -t` before restarting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/913)
<!-- Reviewable:end -->
