### PR TITLE
Add makedepend package on MacOS

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -34,6 +34,7 @@ servo-dependencies:
       - gst-plugins-good
       - gst-plugins-bad
       - llvm
+      - makedepend
       - openssl
       - pkg-config
       - wget


### PR DESCRIPTION
Add the makedepend package on MacOS, to deal with failed builds like https://build.servo.org/builders/magicleap/builds/4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/915)
<!-- Reviewable:end -->
