### PR TITLE
Don't remove execute permission from magicleap sdk files

### DIFF
--- a/servo-build-dependencies/mac-magicleap.sls
+++ b/servo-build-dependencies/mac-magicleap.sls
@@ -12,13 +12,8 @@ include:
   file.directory:
     - user: servo
     - group: staff
-    - dir_mode: 755
-    - file_mode: 644
+    - mode: 755
     - makedirs: True
-    - recurse:
-      - user
-      - group
-      - mode
 
 mac-magicleap:
   cmd.run:


### PR DESCRIPTION
Fixes build problems such as http://build.servo.org/builders/magicleap/builds/11
```
/Users/servo/magicleap/v0.17.0/tools/toolchains/bin/aarch64-linux-android-clang: Permission denied
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/916)
<!-- Reviewable:end -->
