### PR TITLE
Gate on magicleap

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -218,8 +218,7 @@ builders = [
     "android",
     "android-mac",
     "android-x86",
-    # Do not gate on the magicleap build for now
-    # "magicleap",
+    "magicleap",
     "arm32",
     "arm64",
     "windows-msvc-dev",
@@ -238,8 +237,7 @@ try_builders = [
     "android",
     "android-mac",
     "android-x86",
-    # Do not gate on the magicleap build for now
-    # "magicleap",
+    "magicleap",
     "arm32",
     "arm64",
     "windows-msvc-dev",


### PR DESCRIPTION
The magicleap builders are pretty reliably green (when I'm not messing around with the app that is) so we should be file gating on the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/921)
<!-- Reviewable:end -->
