### PR TITLE
Update gstreamer binaries with libav/h264 support

### DIFF
--- a/servo-build-dependencies/linux-gstreamer.sls
+++ b/servo-build-dependencies/linux-gstreamer.sls
@@ -6,8 +6,8 @@ include:
 libs-gstreamer:
   archive.extracted:
     - name: {{ common.servo_home }}
-    - source: http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz
-    - source_hash: sha512=82ec74cd893592b5eefaa7f666bfb51bf70c09bd91b2a34038ff6d46d851b0c9ce1784a56bce1e01c79388296c4d3245d7542e79273c7f372cbc9d35fb1bcd87
+    - source: http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.14.3-20190108-1652.tar.gz
+    - source_hash: sha512=456f30642004bda567ae97f0c76450063528ac6b28745496785fabeb629f65c27ca1133169a2eb8e96f6952089a75bc119e7c385ac6458d09f4d3df1c72fbbf8
     - archive_format: tar
     - user: servo
     - group: servo


### PR DESCRIPTION
More context: https://github.com/servo/servo/pull/22477#issuecomment-449747538 and following comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/935)
<!-- Reviewable:end -->
