### PR TITLE
Add NTP service that relies on AWS NTP servers to avoid clock drift.

### DIFF
--- a/ubuntu/files/ntp.conf
+++ b/ubuntu/files/ntp.conf
@@ -1,0 +1,61 @@
+# /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntp/ntp.drift
+
+
+# Enable this if you want statistics to be logged.
+#statsdir /var/log/ntpstats/
+
+statistics loopstats peerstats clockstats
+filegen loopstats file loopstats type day enable
+filegen peerstats file peerstats type day enable
+filegen clockstats file clockstats type day enable
+
+# Specify one or more NTP servers.
+
+# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
+# on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for
+# more information.
+#server 0.ubuntu.pool.ntp.org
+#server 1.ubuntu.pool.ntp.org
+#server 2.ubuntu.pool.ntp.org
+#server 3.ubuntu.pool.ntp.org
+# Use the Amazon NTP servers to avoid RequestTimeTooSkewed errors:
+# https://www.allcloud.io/how-to/how-to-fix-amazon-s3-requesttimetooskewed/
+server 0.amazon.pool.ntp.org iburst
+server 1.amazon.pool.ntp.org iburst
+server 2.amazon.pool.ntp.org iburst
+server 3.amazon.pool.ntp.org iburst
+
+# Use Ubuntu's ntp server as a fallback.
+server ntp.ubuntu.com
+
+# Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
+# details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
+# might also be helpful.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict -4 default kod notrap nomodify nopeer noquery
+restrict -6 default kod notrap nomodify nopeer noquery
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1
+
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+
+# If you want to provide time to your local subnet, change the next line.
+# (Again, the address is an example only.)
+#broadcast 192.168.123.255
+
+# If you want to listen to time broadcasts on your local subnet, de-comment the
+# next lines.  Please do this only if you trust everybody on the network!
+#disable auth
+#broadcastclient

--- a/ubuntu/init.sls
+++ b/ubuntu/init.sls
@@ -44,3 +44,16 @@ refresh_pkg_db:
     - name: pkg.refresh_db
     - onchanges:
         - file: /etc/apt/sources.list
+
+ntp:
+  pkg.installed:
+    - name: ntp
+  service.running:
+    - watch:
+      - file: /etc/ntp.conf
+  file.managed:
+    - name: /etc/ntp.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - source: salt://{{ tpldir }}/files/ntp.conf


### PR DESCRIPTION
I have done this manually on the linux cross builders which were exhibiting the same problem previously, and it went away. Based on https://www.allcloud.io/how-to/how-to-fix-amazon-s3-requesttimetooskewed/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/949)
<!-- Reviewable:end -->
