### PR TITLE
Add `jq` in server-build-dependencies for upstream WPT sync

### DIFF
--- a/servo-build-dependencies/init.sls
+++ b/servo-build-dependencies/init.sls
@@ -33,6 +33,7 @@ servo-dependencies:
       - gst-plugins-base
       - gst-plugins-good
       - gst-plugins-bad
+      - jq
       - llvm
       - makedepend
       - openssl

--- a/upstream-wpt-webhook/init.sls
+++ b/upstream-wpt-webhook/init.sls
@@ -26,7 +26,6 @@ upstream-wpt-webhook:
   pkg.installed:
     - pkgs:
       - patchutils
-      - jq
   pip.installed:
     - pkgs:
       - git+https://github.com/servo-automation/upstream-wpt-sync-webhook@{{ webhook.rev }}


### PR DESCRIPTION
We missed to add it in wrong place in  #954.
As @jdm mentioned, we should add `jq` in server build dependencies instead; or, the upstream wpt webhook one will only affect servo-mac1.