### PR TITLE
Add salt master to hosts.

### DIFF
--- a/admin/files/hosts
+++ b/admin/files/hosts
@@ -1,3 +1,4 @@
 127.0.0.1	localhost
 ::1		localhost
 255.255.255.255	broadcasthost
+52.37.76.55 salt


### PR DESCRIPTION
Without this, the entry added in [the docs](https://github.com/servo/servo/wiki/SaltStack-Administration) gets overwritten. This causes problems next time the salt-minion service is restarted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/959)
<!-- Reviewable:end -->
