### PR TITLE
Redirect http://build.servo.org/ to HTTPS

### DIFF
--- a/nginx/default
+++ b/nginx/default
@@ -1,10 +1,14 @@
 server {
   listen 80 default_server;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
   server_name build.servo.org;
+
   ssl_certificate /etc/letsencrypt/live/build.servo.org/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/build.servo.org/privkey.pem;
-
-  listen 443 ssl;
 
   location / {
     proxy_pass http://localhost:8010/;


### PR DESCRIPTION
This is untested, but matches what https://ssl-config.mozilla.org/ suggests. (This could be a good time to apply other suggestions from there too.)