### PR TITLE
Improve TLS config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,5 @@ matrix:
 script: .travis/dispatch.sh
 
 notifications:
-  webhooks: http://build.servo.org:54856/travis
   irc: "irc.mozilla.org#servo-bots"
 

--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -139,7 +139,7 @@ c['builders'] = [
 
 c['status'] = [
     status_push.HttpStatusPush(
-        serverUrl='http://build.servo.org:54856/buildbot',
+        serverUrl='https://build.servo.org/homu/buildbot',
         extra_post_params={'secret': HOMU_BUILDBOT_SECRET},
     ),
     html.WebStatus(
@@ -184,8 +184,8 @@ c['status'] = [
 
 
 c['title'] = "Servo"
-c['titleURL'] = "http://github.com/servo/servo"
-c['buildbotURL'] = "http://build.servo.org/"
+c['titleURL'] = "https://github.com/servo/servo"
+c['buildbotURL'] = "https://build.servo.org/"
 
 
 ##################

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -223,7 +223,7 @@ secret = "{{ secrets['web-secret'] }}"
 ] %}
 
 [repo.servo.buildbot]
-url = "http://build.servo.org"
+url = "https://build.servo.org"
 secret = "{{ secrets["buildbot-secret"] }}"
 builders = [
     "linux-rel-css",

--- a/nginx/default
+++ b/nginx/default
@@ -1,15 +1,23 @@
 server {
   listen 80 default_server;
+  listen 443 ssl;
   server_name build.servo.org;
+  ssl_protocols TLSv1.2;
+  ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256;
   ssl_certificate /etc/letsencrypt/live/build.servo.org/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/build.servo.org/privkey.pem;
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
 
-  listen 443 ssl;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
   location / {
     proxy_pass http://localhost:8010/;
   }
-
+  location /github-buildbot-webhook/ {
+    proxy_pass http://localhost:9010/;
+  }
   location /homu/ {
     proxy_pass http://localhost:54856/;
   }

--- a/servo-build-dependencies/linux-gstreamer.sls
+++ b/servo-build-dependencies/linux-gstreamer.sls
@@ -6,7 +6,7 @@ include:
 libs-gstreamer:
   archive.extracted:
     - name: {{ common.servo_home }}
-    - source: http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz
+    - source: https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz
     - source_hash: sha512=1a003f8fdf8fcb3a80b871600da2b7db34267b7e587820ce6442e85eb6aab3b956de7e5aaf08221e65bcb301df48c9d5ce75bb11b7f20ef77b5be5901f2a6e27
     - archive_format: tar
     - user: servo


### PR DESCRIPTION
https://github.com/servo/saltfs/pull/973#issuecomment-517108103
> iirc last time I made this change I broke our buildbot CI completely. This will need to wait until I see convincing evidence that that won't happen again.

Do you mean https://github.com/servo/saltfs/pull/913#issuecomment-437125507?
You broke it under stress without further notice. :-/
It was like changing http://example.com:80/ to https://example.com:80/.
HTTPS is only configured on nginx port 443.

> In particular, I believe that there are some python-based HTTP requests for build.servo.org that see a 301 response and raise an exception.

As far as I can see port 80 is only used by web UI. If the transition is done, port 80 can anyway be closed, so I didn't touch it.

* https://github.com/servo/saltfs/pull/913#issuecomment-437125507: Github webhooks connect to plaintext port http://build.servo.org:9010/. This PR additionally introduces https://build.servo.org/github-buildbot-webhook/. Github can later be changed to use it.
* This PR removes the Travis webhook like it was done for other repos.
* https://github.com/servo/saltfs/blob/8370c3969cdaa2b4733d4ca2a6cc8e49fa4e9ef7/buildbot/master/files/config/master.cfg#L188 This URL is for example returned by the JSON API: https://build.servo.org/json?as_text=1 I did not find other usage. [[1]](https://github.com/search?q=org%3Aservo-automation+buildbotURL&type=Code) [[2]](https://github.com/search?q=org%3Aservo+buildbotURL&type=Code) This PR changes it to https.
* https://github.com/servo/saltfs/blob/6de004289ff289cb909eac0df5e6389dbfa601d8/homu/files/cfg.toml#L226 This is for links to linux-rel-css & linux-rel-wpt on Github comments. Example: https://github.com/servo/servo/pull/23900#issuecomment-517209490 This PR changes it to https. Web browsers already upgrade to HTTPS due to HSTS preloading.
* https://github.com/servo/buildbotstatus/blob/fee4a03826be878edab409b0ac779f97751a6fd9/app/scripts/config.js#L1 Buildbotstatus already uses Buildbot's https JSON API.
* https://github.com/servo/servo/blob/f1dd31f70440fa9c7a40525bd1e03eede568f74d/etc/ci/performance/download_buildbot_timings.py#L27 Buildbot timings are downloaded via https.
* https://github.com/servo/servo/blob/510ffde3f18d02f19be1e90baa903239922a8e49/python/servo/testing_commands.py#L511 Intermittent tracker is already used via https.
* Other services are directly accessed on their own plaintext port. Mostly on localhost.
* Outdated nginx 1.10.3 is used on this Ubuntu 16.04 server. TLS 1.3 is not supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/saltfs/974)
<!-- Reviewable:end -->
