### PR TITLE
Gate servo/servo PRs on the `community-tc` deployment of Taskcluster

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -278,6 +278,9 @@ context = 'Taskcluster (push)'
 
 # Specialized per-repo configs
 
+[repo.servo.status.community-tc]
+context = 'Community-TC (push)'
+
 [repo.glutin.branch]
 master = "servo"
 


### PR DESCRIPTION
… in addition to the legacy deployment, for now. That one will be removed after the transition is finished.

CC https://bugzilla.mozilla.org/show_bug.cgi?id=1574648