### PR TITLE
Disable gating servo/servo PRs on Buildbot

### DIFF
--- a/buildbot/master/files/config/master.cfg
+++ b/buildbot/master/files/config/master.cfg
@@ -62,9 +62,6 @@ c['schedulers'].append(schedulers.AnyBranchScheduler(
     name="servo-auto",
     treeStableTimer=None,
     builderNames=[
-        "linux-rel-css",
-        "linux-rel-nogate",
-        "linux-rel-wpt",
     ],
     change_filter=util.ChangeFilter(filter_fn=servo_auto_try_filter),
 ))

--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -219,12 +219,8 @@ secret = "{{ secrets['web-secret'] }}"
 url = "http://build.servo.org"
 secret = "{{ secrets["buildbot-secret"] }}"
 builders = [
-    "linux-rel-css",
-    "linux-rel-wpt",
 ]
 try_builders = [
-    "linux-rel-css",
-    "linux-rel-wpt",
 ]
 username = "{{ secrets["buildbot-http-user"] }}"
 password = "{{ secrets["buildbot-http-pass"] }}"

--- a/homu/map.jinja
+++ b/homu/map.jinja
@@ -14,7 +14,7 @@
         'linux': [],
         'mac': [],
         'windows': [],
-        'wpt': ['linux-rel-css', 'linux-rel-wpt'],
+        'wpt': [],
         'wpt-mac': [],
         'wpt-android': [],
         'android': [],


### PR DESCRIPTION
It’s only no-op jobs since https://github.com/servo/servo/pull/24785

This doesn’t yet shut down Buildbot or remove its config, in case we want to move back.

Fixes https://github.com/servo/servo/issues/22325