### PR TITLE
Remove appveyor from webrender.

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -134,7 +134,6 @@ secret = "{{ secrets['web-secret'] }}"
     "webrender": {
         "extra_reviewers": [ "nical", "Gankro", "staktrace", "moz-gfx" ],
         "taskcluster": True,
-        "appveyor": True,
         "travis": False,
     },
     "webrender_traits": {


### PR DESCRIPTION
We're turning it off since it now consistently exceeds the CI timeout, and there's already mozilla-central windows testing.