### PR TITLE
intermittent-tracker: deploy servo/intermittent-tracker#5 and #6

### DIFF
--- a/.travis/test_pillars/homu.sls
+++ b/.travis/test_pillars/homu.sls
@@ -1,6 +1,7 @@
 homu:
   'gh-access-token': 'TEST_HOMU_GH_ACCESS_TOKEN'
   'gh-webhook-secret': 'TEST_HOMU_GH_WEBHOOK_SECRET'
+  'intermittent-dashboard-secret': 'TEST_HOMU_INTERMITTENT_DASHBOARD_SECRET'
   'app-client-id': 'TEST_HOMU_APP_CLIENT_ID'
   'app-client-secret': 'TEST_HOMU_APP_CLIENT_SECRET'
   'buildbot-secret': 'TEST_HOMU_BUILDBOT_SECRET'

--- a/intermittent-tracker/files/config.json
+++ b/intermittent-tracker/files/config.json
@@ -1,1 +1,1 @@
-{"token": "{{ pillar["homu"]["gh-access-token"] }}", "port": 5000}
+{"github_token": "{{ pillar["homu"]["gh-access-token"] }}", "dashboard_secret": "{{ pillar["homu"]["intermittent-dashboard-secret"] }}", "port": 5000}

--- a/intermittent-tracker/init.sls
+++ b/intermittent-tracker/init.sls
@@ -13,7 +13,7 @@ tracker-debugging-packages:
 intermittent-tracker:
   virtualenv.managed:
     - name: /home/servo/intermittent-tracker/_venv
-    - venv_bin: virtualenv-3.5
+    - venv_bin: virtualenv
     - python: python3
     - system_site_packages: False
     - require:

--- a/intermittent-tracker/map.jinja
+++ b/intermittent-tracker/map.jinja
@@ -1,5 +1,5 @@
 {%
   set tracker = {
-    'rev': '85d047284df38dbb8ea7e9e4fe26ddaa4bf0a6a7'
+    'rev': 'aac7037ba7bf1bb31e3e1c61d9ef31461ec6c661'
   }
 %}

--- a/intermittent-tracker/map.jinja
+++ b/intermittent-tracker/map.jinja
@@ -1,5 +1,5 @@
 {%
   set tracker = {
-    'rev': 'aac7037ba7bf1bb31e3e1c61d9ef31461ec6c661'
+    'rev': '1f4f9124dcdee4a2d652f7b95f40976d2918123a'
   }
 %}


### PR DESCRIPTION
This patch makes the changes needed to deploy servo/intermittent-tracker#5 + servo/intermittent-tracker#6.

We’ll need to generate an `intermittent-dashboard-secret` as follows:

```sh
$ python3 -c 'import secrets; print(secrets.token_urlsafe())'
ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
```