### PR TITLE
intermittent-tracker: deploy servo/intermittent-tracker#7 and #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## What's going on?
 
 Salt is a configuration management tool that we use to automate Servo's
-infrastructure. See [the tutorials](https://docs.saltstack.com/en/2016.3/topics/tutorials/index.html) to get started.
+infrastructure. See [docs/salt.md](docs/salt.md) to get started.
 
 ## Contributing
 

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -12,7 +12,8 @@ We use [SaltStack](https://saltstack.com/) (Salt for short)
 to configure our infrastructure machines.
 
 We're currently on the Salt 2019.2 release branch, so make sure to look at the
-[right version of the docs](https://docs.saltstack.com/en/2019.5/contents.html).
+[right version of the docs](https://docs.saltstack.com/en/2019.2/contents.html)
+and [tutorials](https://docs.saltstack.com/en/2019.2/topics/tutorials/index.html).
 
 Salt configurations are meant to be idempotent and can be applied as many times
 as you like; a single deploy is termed a `highstate`, which

--- a/intermittent-tracker/init.sls
+++ b/intermittent-tracker/init.sls
@@ -20,12 +20,18 @@ intermittent-tracker:
       - pkg: python3
       - pip: virtualenv
   pip.installed:
+    # pinned deps by specifying both pkgs and requirements (to verify this
+    # behaviour, try checking out the tracker repo, downgrading something in
+    # requirements.txt, and running `pip install -r requirements.txt .`)
     - pkgs:
       - git+https://github.com/servo/intermittent-tracker@{{ tracker.rev }}
+    - requirements:
+      - /home/servo/intermittent-tracker/requirements.txt
     - bin_env: /home/servo/intermittent-tracker/_venv
-    - upgrade: True
+    - force_reinstall: True  # upgrade: True doesn’t work for git+@ packages
     - require:
       - virtualenv: intermittent-tracker
+      - file: /home/servo/intermittent-tracker/requirements.txt
   service.running:
     - enable: True
     - name: tracker
@@ -35,6 +41,13 @@ intermittent-tracker:
       - file: /home/servo/intermittent-tracker/config.json
       - file: /lib/systemd/system/tracker.service
       - pip: intermittent-tracker
+
+/home/servo/intermittent-tracker/requirements.txt:
+  file.managed:
+    - source: https://github.com/servo/intermittent-tracker/raw/{{ tracker.rev }}/requirements.txt
+    - user: root
+    - group: root
+    - mode: 644
 
 /home/servo/intermittent-tracker/config.json:
   file.managed:

--- a/intermittent-tracker/map.jinja
+++ b/intermittent-tracker/map.jinja
@@ -1,5 +1,5 @@
 {%
   set tracker = {
-    'rev': '85d047284df38dbb8ea7e9e4fe26ddaa4bf0a6a7'
+    'rev': '50beef64be19a6302d34d9f582d942a38af45869'
   }
 %}

--- a/intermittent-tracker/map.jinja
+++ b/intermittent-tracker/map.jinja
@@ -1,5 +1,5 @@
 {%
   set tracker = {
-    'rev': '50beef64be19a6302d34d9f582d942a38af45869'
+    'rev': 'f0ada1bd444f800f9916e97789452d261fc707e7'
   }
 %}


### PR DESCRIPTION
This patch fixes intermittent-tracker upgrades, which weren’t actually being deployed due to pip --upgrade behaviour,

```
$ cat ~servo/intermittent-tracker/_venv/lib/python*/site-packages/intermittent_tracker-*.dist-info/direct_url.json
{"url": "https://github.com/servo/intermittent-tracker", "vcs_info": {"commit_id": "85d047284df38dbb8ea7e9e4fe26ddaa4bf0a6a7", "requested_revision": "85d047284df38dbb8ea7e9e4fe26ddaa4bf0a6a7", "vcs": "git"}}
```

will deploy servo/intermittent-tracker#7 and servo/intermittent-tracker#8, and pins deps to the new requirements.txt to avoid inadvertent upgrades, which are more likely now that we use pip --force-reinstall rather than pip --upgrade.

Unrelated to this, we also update the README to point to docs/salt.md, and update the salt docs links there.