### PR TITLE
Re-add additional reviewers for rust-url

### DIFF
--- a/homu/files/cfg.toml
+++ b/homu/files/cfg.toml
@@ -169,7 +169,7 @@ secret = "{{ secrets['web-secret'] }}"
     },
     "rust-stb-image": {},
     "rust-url": {
-        "extra_reviewers": [ "Hoverbear" ],
+        "extra_reviewers": [ "Hoverbear", "valenting", "lucacasonato" ],
     },
     "rust-websocket": {},
     "rust-webvr": {


### PR DESCRIPTION
Hey, during the [recent Servo TSC Github permission cleanup](https://github.com/servo/rust-url/pull/839#issuecomment-1571352449), @valenting and I lost access to `rust-url` to do reviews. We have been maintaining it for the past year and a bit, and it would be great to have review access again. Is this the right way?

