### PR TITLE
Don't run the homu / bors service

### DIFF
--- a/top.sls
+++ b/top.sls
@@ -15,7 +15,6 @@ base:
   'servo-master\d+':
     - match: pcre
     - git
-    - homu
     - intermittent-tracker
     - intermittent-failure-tracker
     - upstream-wpt-webhook


### PR DESCRIPTION
This has been replaced entirely by GitHub Actions.